### PR TITLE
docs: add pheidon governance contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@
 - GitHub issues are the source of record for agent execution work.
 - Worker agents should act from assigned or explicitly enabled issues, not free-roaming backlog grabs.
 - If an agent authors a PR, that same agent may not approve it. This is a hard rule.
+- PR owners must repair their own PRs until merge-ready, including CI failures, rebase/behind-state fixes, mergeability fixes, and requested review changes, unless Pheidon explicitly reassigns ownership.
 - Healthy PRs should converge toward auto-merge once required checks are green or intentionally skipped, approvals are satisfied, and no blocking review state remains.
 - PRs should link and close their governing issue where possible so issue state remains the durable work contract.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,15 @@
 - Add or update tests for every interactive, branching, or operator-facing behavior change.
 - Never commit real secrets, runtime auth, or machine-local env files. Use templates and GitHub environments instead.
 
+## Kingdom Governance
+
+- Pheidon is the orchestrator and current gate for repo execution work.
+- GitHub issues are the source of record for agent execution work.
+- Worker agents should act from assigned or explicitly enabled issues, not free-roaming backlog grabs.
+- If an agent authors a PR, that same agent may not approve it. This is a hard rule.
+- Healthy PRs should converge toward auto-merge once required checks are green or intentionally skipped, approvals are satisfied, and no blocking review state remains.
+- PRs should link and close their governing issue where possible so issue state remains the durable work contract.
+
 ## Local Conventions
 
 - Keep scope tight and favor predictable templates over clever scaffolding.


### PR DESCRIPTION
## Summary
- add a kingdom governance section to the repo AGENTS contract
- document Pheidon as orchestrator and current gate for repo execution work
- document issue-driven work, no self-approval by PR authors, and auto-merge as the intended healthy end-state

## Why
This aligns the non-forked OMT-Global repos with the current Pheidon runtime and governance model.
