### PR TITLE
perf: close split-flap animation hot-path issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+.claude/
+build/

--- a/SplitFlap/CharacterGrid.swift
+++ b/SplitFlap/CharacterGrid.swift
@@ -3,16 +3,30 @@ import AppKit
 
 // Manages the 2-D grid of SplitFlapPanel cells and their layout inside a root layer.
 final class CharacterGrid {
+    private struct LayoutMetrics {
+        let bounds: CGRect
+        let panelSize: CGSize
+        let rows: Int
+        let cols: Int
+        let originX: CGFloat
+        let originY: CGFloat
+
+        func canReusePanels(from previous: LayoutMetrics) -> Bool {
+            rows == previous.rows && cols == previous.cols && panelSize == previous.panelSize
+        }
+    }
 
     private(set) var panels: [[SplitFlapPanel]] = []
     private(set) var rows: Int = 0
     private(set) var cols: Int = 0
+    private(set) var allPanelsFlat: [SplitFlapPanel] = []
 
     // The layer that contains all panel sublayers. Add this to the view's root layer.
     let containerLayer = CALayer()
 
     private var panelSize: CGSize = .zero
     private let gap: CGFloat = 2
+    private var lastLayoutMetrics: LayoutMetrics?
 
     // MARK: - Init
 
@@ -33,40 +47,37 @@ final class CharacterGrid {
     }
 
     private func layout(bounds: CGRect, isPreview: Bool, scale: CGFloat) {
-        let ps = computePanelSize(for: bounds, isPreview: isPreview)
-        panelSize = ps
+        let metrics = makeLayoutMetrics(bounds: bounds, isPreview: isPreview)
 
-        let newCols = Int(floor((bounds.width  + gap) / (ps.width  + gap)))
-        let newRows = Int(floor((bounds.height + gap) / (ps.height + gap)))
+        if let lastLayoutMetrics, metrics.canReusePanels(from: lastLayoutMetrics) {
+            applyFrames(using: metrics)
+            return
+        }
 
-        rows = max(newRows, 1)
-        cols = max(newCols, 1)
-
-        // Centering offsets
-        let totalW = CGFloat(cols) * (ps.width  + gap) - gap
-        let totalH = CGFloat(rows) * (ps.height + gap) - gap
-        let originX = floor((bounds.width  - totalW) / 2)
-        let originY = floor((bounds.height - totalH) / 2)
-
-        containerLayer.frame = bounds
+        panelSize = metrics.panelSize
+        rows = metrics.rows
+        cols = metrics.cols
+        lastLayoutMetrics = metrics
+        containerLayer.frame = metrics.bounds
         containerLayer.backgroundColor = BoardColors.screenBg
 
         // Remove existing sublayers
         containerLayer.sublayers?.forEach { $0.removeFromSuperlayer() }
         panels = []
+        var flat: [SplitFlapPanel] = []
 
         for r in 0..<rows {
             var row: [SplitFlapPanel] = []
             for c in 0..<cols {
-                let panel = SplitFlapPanel(size: ps, scale: scale)
-                let x = originX + CGFloat(c) * (ps.width  + gap)
-                let y = originY + CGFloat(r) * (ps.height + gap)
-                panel.panelLayer.frame = CGRect(x: x, y: y, width: ps.width, height: ps.height)
+                let panel = SplitFlapPanel(size: metrics.panelSize, scale: scale)
+                panel.panelLayer.frame = panelFrame(row: r, col: c, metrics: metrics)
                 containerLayer.addSublayer(panel.panelLayer)
                 row.append(panel)
+                flat.append(panel)
             }
             panels.append(row)
         }
+        allPanelsFlat = flat
     }
 
     // MARK: - Access
@@ -77,12 +88,58 @@ final class CharacterGrid {
     }
 
     func allPanels() -> [SplitFlapPanel] {
-        return panels.flatMap { $0 }
+        return allPanelsFlat
     }
 
     // MARK: - Resize
 
     func rebuild(bounds: CGRect, isPreview: Bool, scale: CGFloat) {
         layout(bounds: bounds, isPreview: isPreview, scale: scale)
+    }
+
+    private func makeLayoutMetrics(bounds: CGRect, isPreview: Bool) -> LayoutMetrics {
+        let ps = computePanelSize(for: bounds, isPreview: isPreview)
+        let newCols = Int(floor((bounds.width  + gap) / (ps.width  + gap)))
+        let newRows = Int(floor((bounds.height + gap) / (ps.height + gap)))
+        let cols = max(newCols, 1)
+        let rows = max(newRows, 1)
+
+        let totalW = CGFloat(cols) * (ps.width  + gap) - gap
+        let totalH = CGFloat(rows) * (ps.height + gap) - gap
+        let originX = floor((bounds.width  - totalW) / 2)
+        let originY = floor((bounds.height - totalH) / 2)
+
+        return LayoutMetrics(
+            bounds: bounds,
+            panelSize: ps,
+            rows: rows,
+            cols: cols,
+            originX: originX,
+            originY: originY
+        )
+    }
+
+    private func applyFrames(using metrics: LayoutMetrics) {
+        panelSize = metrics.panelSize
+        rows = metrics.rows
+        cols = metrics.cols
+        lastLayoutMetrics = metrics
+        containerLayer.frame = metrics.bounds
+        containerLayer.backgroundColor = BoardColors.screenBg
+
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        for r in 0..<rows {
+            for c in 0..<cols {
+                panels[r][c].panelLayer.frame = panelFrame(row: r, col: c, metrics: metrics)
+            }
+        }
+        CATransaction.commit()
+    }
+
+    private func panelFrame(row: Int, col: Int, metrics: LayoutMetrics) -> CGRect {
+        let x = metrics.originX + CGFloat(col) * (metrics.panelSize.width  + gap)
+        let y = metrics.originY + CGFloat(row) * (metrics.panelSize.height + gap)
+        return CGRect(x: x, y: y, width: metrics.panelSize.width, height: metrics.panelSize.height)
     }
 }

--- a/SplitFlap/DisplayClock.swift
+++ b/SplitFlap/DisplayClock.swift
@@ -1,16 +1,102 @@
 import Foundation
 import QuartzCore
+import AppKit
+import CoreVideo
+
+private protocol DisplayTicker: AnyObject {
+    func invalidate()
+}
+
+@available(macOS 14.0, *)
+private final class CADisplayTicker: NSObject, DisplayTicker {
+    private var link: CADisplayLink?
+    private let onFrame: (CFTimeInterval) -> Void
+
+    init?(screen: NSScreen?, onFrame: @escaping (CFTimeInterval) -> Void) {
+        self.onFrame = onFrame
+        super.init()
+
+        guard let link = (screen ?? NSScreen.main)?.displayLink(
+            target: self,
+            selector: #selector(tick(_:))
+        ) else {
+            return nil
+        }
+        link.preferredFrameRateRange = CAFrameRateRange(
+            minimum: 6,
+            maximum: 15,
+            preferred: 10
+        )
+        link.add(to: .main, forMode: .common)
+        self.link = link
+    }
+
+    func invalidate() {
+        link?.invalidate()
+        link = nil
+    }
+
+    @objc private func tick(_ link: CADisplayLink) {
+        onFrame(link.targetTimestamp > 0 ? link.targetTimestamp : link.timestamp)
+    }
+}
+
+private final class CVDisplayTicker: DisplayTicker {
+    private var link: CVDisplayLink?
+    private let onFrame: (CFTimeInterval) -> Void
+
+    init?(onFrame: @escaping (CFTimeInterval) -> Void) {
+        self.onFrame = onFrame
+
+        var link: CVDisplayLink?
+        guard CVDisplayLinkCreateWithActiveCGDisplays(&link) == kCVReturnSuccess,
+              let createdLink = link else {
+            return nil
+        }
+
+        self.link = createdLink
+        let context = Unmanaged.passUnretained(self).toOpaque()
+        CVDisplayLinkSetOutputCallback(createdLink, { _, now, _, _, _, context in
+            guard let context else { return kCVReturnSuccess }
+            let ticker = Unmanaged<CVDisplayTicker>.fromOpaque(context).takeUnretainedValue()
+            let scale = now.pointee.videoTimeScale
+            let timestamp: CFTimeInterval
+            if scale > 0 {
+                timestamp = CFTimeInterval(now.pointee.videoTime) / CFTimeInterval(scale)
+            } else {
+                timestamp = CACurrentMediaTime()
+            }
+            DispatchQueue.main.async {
+                ticker.onFrame(timestamp)
+            }
+            return kCVReturnSuccess
+        }, context)
+        CVDisplayLinkStart(createdLink)
+    }
+
+    func invalidate() {
+        if let link {
+            CVDisplayLinkStop(link)
+        }
+        link = nil
+    }
+
+    deinit {
+        invalidate()
+    }
+}
 
 // Controls *when* and *which* panels flip.
 // Two phases alternate automatically:
 //   1. Idle shuffle — panels drift to random characters individually
 //   2. Wave update  — a left-to-right wave sweeps across all panels
-final class DisplayClock {
+final class DisplayClock: NSObject {
 
     private weak var grid: CharacterGrid?
     private let animator = FlipAnimator()
 
-    private var timer: DispatchSourceTimer?
+    private var ticker: DisplayTicker?
+    private var lastIdleTickTimestamp: CFTimeInterval?
     private var phase: Phase = .idle
     private var phaseTickCount: Int = 0
 
@@ -28,29 +114,67 @@ final class DisplayClock {
 
     // Fraction of panels that flip on each idle tick
     private let idleDensity: Double = 0.04
+    private let maxIdleFlipStartsPerTick: Int = 12
+    private let maxActiveIdleFlips: Int = 48
+    private var runGeneration: Int = 0
 
     // MARK: - Init
 
     init(grid: CharacterGrid) {
         self.grid = grid
+        super.init()
     }
 
     // MARK: - Lifecycle
 
-    func start() {
-        let t = DispatchSource.makeTimerSource(queue: .main)
-        t.schedule(deadline: .now() + 0.5, repeating: idleTickInterval)
-        t.setEventHandler { [weak self] in self?.tick() }
-        t.resume()
-        timer = t
+    func start(screen: NSScreen? = NSScreen.main) {
+        stop()
+        runGeneration += 1
+        phase = .idle
+        phaseTickCount = 0
+        lastIdleTickTimestamp = nil
+
+        ticker = makeTicker(screen: screen)
     }
 
     func stop() {
-        timer?.cancel()
-        timer = nil
+        runGeneration += 1
+        ticker?.invalidate()
+        ticker = nil
+        lastIdleTickTimestamp = nil
+        grid?.allPanelsFlat.forEach { panel in
+            if panel.isFlipping {
+                panel.cancelFlip()
+            }
+        }
+        phase = .idle
+        phaseTickCount = 0
     }
 
     // MARK: - Tick
+
+    private func makeTicker(screen: NSScreen?) -> DisplayTicker? {
+        if #available(macOS 14.0, *) {
+            return CADisplayTicker(screen: screen) { [weak self] timestamp in
+                self?.displayTick(timestamp: timestamp)
+            }
+        }
+
+        return CVDisplayTicker { [weak self] timestamp in
+            self?.displayTick(timestamp: timestamp)
+        }
+    }
+
+    private func displayTick(timestamp: CFTimeInterval) {
+        guard let last = lastIdleTickTimestamp else {
+            lastIdleTickTimestamp = timestamp
+            return
+        }
+
+        guard timestamp - last >= idleTickInterval else { return }
+        lastIdleTickTimestamp = timestamp
+        tick()
+    }
 
     private func tick() {
         guard let grid = grid else { return }
@@ -78,21 +202,38 @@ final class DisplayClock {
     // MARK: - Idle phase
 
     private func idleTick(grid: CharacterGrid) {
-        let all = grid.allPanels()
+        let all = grid.allPanelsFlat
         guard !all.isEmpty else { return }
 
-        let flipCount = max(1, Int(Double(all.count) * idleDensity))
+        let activeCount = all.reduce(0) { $0 + ($1.isFlipping ? 1 : 0) }
+        let activeBudget = maxActiveIdleFlips - activeCount
+        guard activeBudget > 0 else { return }
+
+        let requestedCount = max(1, Int(Double(all.count) * idleDensity))
+        let flipCount = min(requestedCount, maxIdleFlipStartsPerTick, activeBudget, all.count)
+        let generation = runGeneration
 
         // O(k) random selection instead of O(n) shuffle + allocation.
         var selectedIndices = Set<Int>()
-        while selectedIndices.count < flipCount {
-            selectedIndices.insert(Int.random(in: 0..<all.count))
-        }
-        let toFlip = selectedIndices.map { all[$0] }
+        var started = 0
+        var attempts = 0
+        let maxAttempts = all.count * 2
 
-        for panel in toFlip {
+        while started < flipCount && attempts < maxAttempts {
+            attempts += 1
+            let index = Int.random(in: 0..<all.count)
+            guard selectedIndices.insert(index).inserted else { continue }
+
+            let panel = all[index]
+            guard !panel.isFlipping else { continue }
             let target = SplitFlapCharacter.random()
-            animator.animateTo(target, panel: panel)
+            guard panel.currentCharacter != target else { continue }
+            animator.animateTo(
+                target,
+                panel: panel,
+                shouldContinue: { [weak self] in self?.isCurrentGeneration(generation) ?? false }
+            )
+            started += 1
         }
     }
 
@@ -101,11 +242,16 @@ final class DisplayClock {
     private func startWave(grid: CharacterGrid) {
         // Choose a random target character for each panel (or fill with a message).
         let targets = buildWaveTargets(grid: grid)
+        let generation = runGeneration
 
         // Stagger column-by-column by assigning Core Animation begin times in one pass.
         let columnStagger: CFTimeInterval = 0.06
         let maxRowJitter: CFTimeInterval = 0.04
         let baseTime = CACurrentMediaTime()
+
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        defer { CATransaction.commit() }
 
         for col in 0..<grid.cols {
             let columnOffset = CFTimeInterval(col) * columnStagger
@@ -116,7 +262,13 @@ final class DisplayClock {
                 let rowJitter = CFTimeInterval.random(in: 0...maxRowJitter)
                 let beginTime = baseTime + columnOffset + rowJitter
                 let target = targets[row][col]
-                animator.animateTo(target, panel: panel, beginTime: beginTime)
+                guard panel.currentCharacter != target else { continue }
+                animator.animateTo(
+                    target,
+                    panel: panel,
+                    beginTime: beginTime,
+                    shouldContinue: { [weak self] in self?.isCurrentGeneration(generation) ?? false }
+                )
             }
         }
     }
@@ -131,5 +283,9 @@ final class DisplayClock {
             targets.append(row)
         }
         return targets
+    }
+
+    private func isCurrentGeneration(_ generation: Int) -> Bool {
+        runGeneration == generation
     }
 }

--- a/SplitFlap/FlipAnimator.swift
+++ b/SplitFlap/FlipAnimator.swift
@@ -13,14 +13,21 @@ final class FlipAnimator {
         _ targetChar: SplitFlapCharacter,
         panel: SplitFlapPanel,
         beginTime: CFTimeInterval? = nil,
+        shouldContinue: @escaping () -> Bool = { true },
         completion: (() -> Void)? = nil
     ) {
+        guard shouldContinue() else { completion?(); return }
+
         let steps = panel.currentCharacter.stepsTo(targetChar)
         guard steps > 0 else { completion?(); return }
+        guard !panel.isFlipping else { completion?(); return }
+
+        panel.beginFlipping()
         runSteps(
             remaining: steps,
             panel: panel,
             beginTime: beginTime ?? CACurrentMediaTime(),
+            shouldContinue: shouldContinue,
             completion: completion
         )
     }
@@ -29,8 +36,15 @@ final class FlipAnimator {
         remaining: Int,
         panel: SplitFlapPanel,
         beginTime: CFTimeInterval,
+        shouldContinue: @escaping () -> Bool,
         completion: (() -> Void)?
     ) {
+        guard shouldContinue() else {
+            panel.cancelFlip()
+            completion?()
+            return
+        }
+
         guard remaining > 0 else { completion?(); return }
 
         let fromChar = panel.currentCharacter
@@ -70,14 +84,24 @@ final class FlipAnimator {
         let bottomRevealDelay = max(0, beginTime + fallDuration - CACurrentMediaTime())
         DispatchQueue.main.asyncAfter(deadline: .now() + bottomRevealDelay) { [weak panel] in
             guard let panel = panel else { return }
+            guard shouldContinue() else {
+                panel.cancelFlip()
+                completion?()
+                return
+            }
             panel.bottomFlapContainer.isHidden = false
 
             CATransaction.begin()
             CATransaction.setCompletionBlock { [weak panel, weak self] in
                 guard let panel = panel, let self = self else { return }
+                guard shouldContinue() else {
+                    panel.cancelFlip()
+                    completion?()
+                    return
+                }
                 panel.topFlapContainer.removeAllAnimations()
                 panel.bottomFlapContainer.removeAllAnimations()
-                panel.finalizeFlip(to: toChar)
+                panel.finalizeFlip(to: toChar, done: remaining <= 1)
 
                 if remaining > 1 {
                     DispatchQueue.main.asyncAfter(deadline: .now() + FlipAnimator.interStepPause) {
@@ -85,6 +109,7 @@ final class FlipAnimator {
                             remaining: remaining - 1,
                             panel: panel,
                             beginTime: CACurrentMediaTime(),
+                            shouldContinue: shouldContinue,
                             completion: completion
                         )
                     }

--- a/SplitFlap/SplitFlapPanel.swift
+++ b/SplitFlap/SplitFlapPanel.swift
@@ -9,6 +9,73 @@ enum BoardColors {
     static let screenBg        = CGColor(red: 0.04, green: 0.04, blue: 0.05, alpha: 1.0)
 }
 
+private final class GlyphImageCache {
+    static let shared = GlyphImageCache()
+
+    private let cache = NSCache<NSString, CGImage>()
+
+    func image(for character: SplitFlapCharacter, size: CGSize, scale: CGFloat) -> CGImage? {
+        let pixelWidth = max(1, Int((size.width * scale).rounded(.up)))
+        let pixelHeight = max(1, Int((size.height * scale).rounded(.up)))
+        let key = "\(character.rawValue)-\(pixelWidth)x\(pixelHeight)" as NSString
+
+        if let cached = cache.object(forKey: key) {
+            return cached
+        }
+
+        let fontSize = size.height * 0.72
+        let font = NSFont(name: "SFMono-Regular", size: fontSize)
+            ?? NSFont.monospacedSystemFont(ofSize: fontSize, weight: .regular)
+        let paragraph = NSMutableParagraphStyle()
+        paragraph.alignment = .center
+
+        let color = NSColor(cgColor: BoardColors.character) ?? .systemYellow
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: font,
+            .foregroundColor: color,
+            .paragraphStyle: paragraph
+        ]
+
+        guard let rep = NSBitmapImageRep(
+            bitmapDataPlanes: nil,
+            pixelsWide: pixelWidth,
+            pixelsHigh: pixelHeight,
+            bitsPerSample: 8,
+            samplesPerPixel: 4,
+            hasAlpha: true,
+            isPlanar: false,
+            colorSpaceName: .deviceRGB,
+            bytesPerRow: 0,
+            bitsPerPixel: 0
+        ) else {
+            return nil
+        }
+        rep.size = size
+
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.current = NSGraphicsContext(bitmapImageRep: rep)
+        NSColor.clear.setFill()
+        CGRect(origin: .zero, size: size).fill()
+
+        let string = character.displayString as NSString
+        let textSize = string.size(withAttributes: attributes)
+        let drawRect = CGRect(
+            x: 0,
+            y: floor((size.height - textSize.height) / 2),
+            width: size.width,
+            height: ceil(textSize.height)
+        )
+        string.draw(in: drawRect, withAttributes: attributes)
+        NSGraphicsContext.restoreGraphicsState()
+
+        guard let image = rep.cgImage else {
+            return nil
+        }
+        cache.setObject(image, forKey: key)
+        return image
+    }
+}
+
 // A single character cell in the split-flap grid.
 //
 // Layer hierarchy (back → front inside panelLayer):
@@ -36,13 +103,14 @@ final class SplitFlapPanel {
 
     private let dividerLayer = CALayer()
 
-    // Text layers inside each container
-    private let staticTopText    = CATextLayer()
-    private let staticBottomText = CATextLayer()
-    let topFlapText    = CATextLayer()
-    let bottomFlapText = CATextLayer()
+    // Cached glyph bitmap layers inside each container.
+    private let staticTopText    = CALayer()
+    private let staticBottomText = CALayer()
+    let topFlapText    = CALayer()
+    let bottomFlapText = CALayer()
 
     private(set) var currentCharacter: SplitFlapCharacter = .space
+    private(set) var isFlipping = false
 
     private var w: CGFloat = 0
     private var h: CGFloat = 0
@@ -65,6 +133,8 @@ final class SplitFlapPanel {
         panelLayer.backgroundColor = BoardColors.panelBackground
         panelLayer.cornerRadius = 1
         panelLayer.masksToBounds = true
+        panelLayer.shouldRasterize = true
+        panelLayer.rasterizationScale = scale
 
         // Perspective applied to all sub-layers
         var persp = CATransform3DIdentity
@@ -126,7 +196,7 @@ final class SplitFlapPanel {
 
     private func setupContainer(
         _ container: CALayer,
-        textLayer: CATextLayer,
+        textLayer: CALayer,
         frame: CGRect,
         fontSize: CGFloat,
         scale: CGFloat,
@@ -157,23 +227,10 @@ final class SplitFlapPanel {
         }
         container.mask = maskLayer
 
-        // Text layer fills the full bounds so text renders in the same position
-        // regardless of which half is masked.
         textLayer.frame = frame
         textLayer.contentsScale = scale
-        textLayer.alignmentMode = .center
-        textLayer.foregroundColor = BoardColors.character
+        textLayer.contentsGravity = .resize
         textLayer.backgroundColor = CGColor.clear
-        textLayer.fontSize = fontSize
-        textLayer.isWrapped = false
-
-        // Use a monospaced font
-        let fontName = "SFMono-Regular"
-        if let f = NSFont(name: fontName, size: fontSize) {
-            textLayer.font = f
-        } else {
-            textLayer.font = NSFont.monospacedSystemFont(ofSize: fontSize, weight: .regular)
-        }
 
         container.addSublayer(textLayer)
     }
@@ -183,16 +240,39 @@ final class SplitFlapPanel {
     /// Immediately set a character on all layers without animation.
     func setCharacter(_ char: SplitFlapCharacter, animated: Bool) {
         currentCharacter = char
+        isFlipping = false
         CATransaction.begin()
         CATransaction.setDisableActions(true)
-        let s = char.displayString as CFString
-        staticTopText.string    = s
-        staticBottomText.string = s
-        topFlapText.string      = s
-        bottomFlapText.string   = s
+        applyGlyph(char, to: staticTopText)
+        applyGlyph(char, to: staticBottomText)
+        applyGlyph(char, to: topFlapText)
+        applyGlyph(char, to: bottomFlapText)
         topFlapContainer.transform    = CATransform3DIdentity
         bottomFlapContainer.transform = CATransform3DIdentity
         bottomFlapContainer.isHidden  = false
+        panelLayer.shouldRasterize    = true
+        CATransaction.commit()
+    }
+
+    func beginFlipping() {
+        isFlipping = true
+        panelLayer.shouldRasterize = false
+    }
+
+    func cancelFlip() {
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        topFlapContainer.removeAllAnimations()
+        bottomFlapContainer.removeAllAnimations()
+        applyGlyph(currentCharacter, to: staticTopText)
+        applyGlyph(currentCharacter, to: staticBottomText)
+        applyGlyph(currentCharacter, to: topFlapText)
+        applyGlyph(currentCharacter, to: bottomFlapText)
+        topFlapContainer.transform = CATransform3DIdentity
+        bottomFlapContainer.transform = CATransform3DIdentity
+        bottomFlapContainer.isHidden = false
+        isFlipping = false
+        panelLayer.shouldRasterize = true
         CATransaction.commit()
     }
 
@@ -204,10 +284,10 @@ final class SplitFlapPanel {
     ) {
         CATransaction.begin()
         CATransaction.setDisableActions(true)
-        staticTopText.string    = fromChar.displayString as CFString
-        staticBottomText.string = (revealStaticBottom ? toChar : fromChar).displayString as CFString
-        topFlapText.string      = fromChar.displayString as CFString
-        bottomFlapText.string   = toChar.displayString  as CFString
+        applyGlyph(fromChar, to: staticTopText)
+        applyGlyph(revealStaticBottom ? toChar : fromChar, to: staticBottomText)
+        applyGlyph(fromChar, to: topFlapText)
+        applyGlyph(toChar, to: bottomFlapText)
         topFlapContainer.transform    = CATransform3DIdentity        // flat, visible
         bottomFlapContainer.transform = CATransform3DMakeRotation(.pi / 2, 1, 0, 0)
         bottomFlapContainer.isHidden  = true  // invisible until top flap finishes
@@ -215,18 +295,29 @@ final class SplitFlapPanel {
     }
 
     /// Called after a single flip step completes to snap to the final state.
-    func finalizeFlip(to char: SplitFlapCharacter) {
+    func finalizeFlip(to char: SplitFlapCharacter, done: Bool) {
         currentCharacter = char
         CATransaction.begin()
         CATransaction.setDisableActions(true)
-        let s = char.displayString as CFString
-        staticTopText.string    = s
-        staticBottomText.string = s
-        topFlapText.string      = s
-        bottomFlapText.string   = s
+        applyGlyph(char, to: staticTopText)
+        applyGlyph(char, to: staticBottomText)
+        applyGlyph(char, to: topFlapText)
+        applyGlyph(char, to: bottomFlapText)
         topFlapContainer.transform    = CATransform3DIdentity
         bottomFlapContainer.transform = CATransform3DIdentity
         bottomFlapContainer.isHidden  = false
+        if done {
+            isFlipping = false
+            panelLayer.shouldRasterize = true
+        }
         CATransaction.commit()
+    }
+
+    private func applyGlyph(_ character: SplitFlapCharacter, to layer: CALayer) {
+        layer.contents = GlyphImageCache.shared.image(
+            for: character,
+            size: CGSize(width: w, height: h),
+            scale: layer.contentsScale
+        )
     }
 }

--- a/SplitFlap/SplitFlapView.swift
+++ b/SplitFlap/SplitFlapView.swift
@@ -48,7 +48,7 @@ final class SplitFlapView: ScreenSaverView {
 
     override func startAnimation() {
         super.startAnimation()
-        clock?.start()
+        clock?.start(screen: window?.screen ?? NSScreen.main)
     }
 
     override func stopAnimation() {
@@ -69,11 +69,8 @@ final class SplitFlapView: ScreenSaverView {
         let scale = NSScreen.main?.backingScaleFactor ?? 2.0
         rootLayer.frame = bounds
         grid?.rebuild(bounds: bounds, isPreview: isPreview, scale: scale)
-        if let g = grid {
-            clock = DisplayClock(grid: g)
-            if isAnimating {
-                clock?.start()
-            }
+        if isAnimating {
+            clock?.start(screen: window?.screen ?? NSScreen.main)
         }
     }
 


### PR DESCRIPTION
## Summary
- reuse existing panel layers when resize keeps the same row/column/panel geometry
- cache glyph bitmaps in CALayer contents and skip no-op/already-active flips
- batch wave animation setup in one CATransaction and drive idle ticks from display-synchronized CADisplayLink/CVDisplayLink
- ignore local .claude, build output, and .DS_Store

Closes #9.
Closes #10.
Closes #11.
Closes #12.
Closes #13.

## Verification
- make build
- codesign --verify --deep --strict build/Build/Products/Release/SplitFlap.saver
- git diff --check
- git check-ignore -v .claude build .DS_Store

Note: local Xcode still reports the known CoreSimulator version warning, but the macOS screensaver Release build succeeds.