### PR TITLE
Normalize CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,2 @@
-* @jmcte
+# Managed CODEOWNERS for OMT-Global native repos.
+* @pheidon @jmcte


### PR DESCRIPTION
## Summary

- Normalize CODEOWNERS so repository ownership is limited to Pheidon and JMCTE.
- Align the repository with the OMT-Global native ownership policy.

## Governing Issue

No governing issue is linked. This PR is a narrow governance/ownership normalization follow-up.

## Validation

- [x] Verified PR Fast CI source checks are green except the PR description gate that this body update repairs.
- [x] Reviewed .github/workflows/pr-fast-ci.yml description requirements locally.
- [x] Confirmed no source changes are needed for this repair.

## Bootstrap Governance

This change keeps bootstrap-managed ownership metadata aligned with the current repository governance model.

## Merge Automation

gh pr merge --auto --squash will be run after the PR body repair. If GitHub rejects auto-merge, the exact blocker will be recorded before handoff.

## Notes

No runtime, product, API, data, auth, payment, upload, or production application behavior changes are included.
