### PR TITLE
perf: drive split-flap flips entirely on the render server

### DIFF
--- a/SplitFlap/DisplayClock.swift
+++ b/SplitFlap/DisplayClock.swift
@@ -219,6 +219,10 @@ final class DisplayClock: NSObject {
         var attempts = 0
         let maxAttempts = all.count * 2
 
+        // Add every flip started this tick inside one transaction so the tick
+        // produces a single render-server commit instead of one per panel.
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
         while started < flipCount && attempts < maxAttempts {
             attempts += 1
             let index = Int.random(in: 0..<all.count)
@@ -231,10 +235,12 @@ final class DisplayClock: NSObject {
             animator.animateTo(
                 target,
                 panel: panel,
+                batchedTransaction: true,
                 shouldContinue: { [weak self] in self?.isCurrentGeneration(generation) ?? false }
             )
             started += 1
         }
+        CATransaction.commit()
     }
 
     // MARK: - Wave phase

--- a/SplitFlap/FlipAnimator.swift
+++ b/SplitFlap/FlipAnimator.swift
@@ -1,14 +1,22 @@
 import QuartzCore
 
-// Drives the CABasicAnimation sequence for one or more sequential flip steps.
-// One step: old top flap falls (0 → -π/2) then new bottom flap rises (π/2 → 0).
+// Entry point for driving a split-flap flip.
+//
+// The entire mechanical sequence — every intermediate character and both
+// half-flap rotations — is built once as a batch of keyframe animations and
+// handed to Core Animation in a single commit (see `SplitFlapPanel.flip`). The
+// render server then plays the whole flip with no per-step work on the app's
+// main thread; a single completion callback fires when it settles. This keeps
+// the screensaver near-idle on the CPU even while hundreds of panels animate.
 final class FlipAnimator {
 
     static let topFallDuration:    CFTimeInterval = 0.075
     static let bottomRiseDuration: CFTimeInterval = 0.065
     static let interStepPause:     CFTimeInterval = 0.018
 
-    // Animate `panel` to `targetChar`, one mechanical step at a time.
+    /// Animate `panel` to `targetChar`. A future `beginTime` schedules the flip
+    /// on the render server (used to stagger the wave sweep); `batchedTransaction`
+    /// lets a caller add many panels inside one CATransaction.
     func animateTo(
         _ targetChar: SplitFlapCharacter,
         panel: SplitFlapPanel,
@@ -18,113 +26,12 @@ final class FlipAnimator {
         completion: (() -> Void)? = nil
     ) {
         guard shouldContinue() else { completion?(); return }
-
-        let steps = panel.currentCharacter.stepsTo(targetChar)
-        guard steps > 0 else { completion?(); return }
-        guard !panel.isFlipping else { completion?(); return }
-
-        panel.beginFlipping()
-        runSteps(
-            remaining: steps,
-            panel: panel,
+        panel.flip(
+            to: targetChar,
             beginTime: beginTime ?? CACurrentMediaTime(),
             batchedTransaction: batchedTransaction,
             shouldContinue: shouldContinue,
             completion: completion
         )
-    }
-
-    private func runSteps(
-        remaining: Int,
-        panel: SplitFlapPanel,
-        beginTime: CFTimeInterval,
-        batchedTransaction: Bool,
-        shouldContinue: @escaping () -> Bool,
-        completion: (() -> Void)?
-    ) {
-        guard shouldContinue() else {
-            panel.cancelFlip()
-            completion?()
-            return
-        }
-
-        guard remaining > 0 else { completion?(); return }
-
-        let fromChar = panel.currentCharacter
-        let toChar   = fromChar.next
-        let startsImmediately = beginTime <= CACurrentMediaTime()
-        panel.prepareFlip(
-            fromChar: fromChar,
-            toChar: toChar,
-            revealStaticBottom: startsImmediately,
-            batchedTransaction: batchedTransaction
-        )
-
-        let fallDuration = FlipAnimator.topFallDuration
-        let riseDuration = FlipAnimator.bottomRiseDuration
-
-        // Phase 1 — top flap falls
-        let topFall = CABasicAnimation(keyPath: "transform.rotation.x")
-        topFall.fromValue = 0.0
-        topFall.toValue   = -Double.pi / 2
-        topFall.duration  = fallDuration
-        topFall.beginTime = beginTime
-        topFall.timingFunction = CAMediaTimingFunction(name: .easeIn)
-        topFall.fillMode = .forwards
-        topFall.isRemovedOnCompletion = false
-
-        // Phase 2 — bottom flap rises after the top flap finishes.
-        let bottomRise = CABasicAnimation(keyPath: "transform.rotation.x")
-        bottomRise.fromValue = Double.pi / 2
-        bottomRise.toValue   = 0.0
-        bottomRise.duration  = riseDuration
-        bottomRise.beginTime = beginTime + fallDuration
-        bottomRise.timingFunction = CAMediaTimingFunction(name: .easeOut)
-        bottomRise.fillMode = .forwards
-        bottomRise.isRemovedOnCompletion = false
-
-        panel.topFlapContainer.add(topFall, forKey: "topFall")
-
-        let bottomRevealDelay = max(0, beginTime + fallDuration - CACurrentMediaTime())
-        DispatchQueue.main.asyncAfter(deadline: .now() + bottomRevealDelay) { [weak panel] in
-            guard let panel = panel else { return }
-            guard shouldContinue() else {
-                panel.cancelFlip()
-                completion?()
-                return
-            }
-            panel.bottomFlapContainer.isHidden = false
-
-            CATransaction.begin()
-            CATransaction.setCompletionBlock { [weak panel, weak self] in
-                guard let panel = panel, let self = self else { return }
-                guard shouldContinue() else {
-                    panel.cancelFlip()
-                    completion?()
-                    return
-                }
-                panel.topFlapContainer.removeAllAnimations()
-                panel.bottomFlapContainer.removeAllAnimations()
-                panel.finalizeFlip(to: toChar, done: remaining <= 1)
-
-                if remaining > 1 {
-                    DispatchQueue.main.asyncAfter(deadline: .now() + FlipAnimator.interStepPause) {
-                        self.runSteps(
-                            remaining: remaining - 1,
-                            panel: panel,
-                            beginTime: CACurrentMediaTime(),
-                            batchedTransaction: false,
-                            shouldContinue: shouldContinue,
-                            completion: completion
-                        )
-                    }
-                } else {
-                    completion?()
-                }
-            }
-
-            panel.bottomFlapContainer.add(bottomRise, forKey: "bottomRise")
-            CATransaction.commit()
-        }
     }
 }

--- a/SplitFlap/SplitFlapPanel.swift
+++ b/SplitFlap/SplitFlapPanel.swift
@@ -22,7 +22,7 @@ private final class GlyphImageCache {
         init(surface: IOSurface) { self.surface = surface }
     }
 
-    private let cache = NSCache<NSString, GlyphSurface>()
+    private let cache = NSCache<NSNumber, GlyphSurface>()
 
     func contents(
         for character: SplitFlapCharacter,
@@ -36,7 +36,14 @@ private final class GlyphImageCache {
 
         let pixelWidth = max(1, Int((panelW * scale).rounded(.up)))
         let pixelHalfHeight = max(1, Int((halfH * scale).rounded(.up)))
-        let key = "\(character.rawValue)-\(pixelWidth)x\(pixelHalfHeight)-\(half.rawValue)" as NSString
+        // Pack the cache identity into a single integer so the hot glyph lookup
+        // (called for every keyframe of every flip) allocates nothing — no
+        // per-call interpolated string. Field widths comfortably fit even an
+        // 8K display: half-height/width stay well under 2^14 pixels.
+        let halfBit = (half == .top) ? 0 : 1
+        let key = NSNumber(
+            value: (pixelWidth << 21) | (pixelHalfHeight << 7) | (character.rawValue << 1) | halfBit
+        )
 
         if let cached = cache.object(forKey: key) {
             return cached.surface
@@ -116,6 +123,25 @@ private final class GlyphImageCache {
         let glyphSurface = GlyphSurface(surface: surface)
         cache.setObject(glyphSurface, forKey: key)
         return surface
+    }
+}
+
+// Fires exactly once when a batched flip animation finishes (or is torn down).
+// The guard prevents a re-entrant callback when the panel removes the
+// animations from inside the completion handler.
+private final class FlipCompletionDelegate: NSObject, CAAnimationDelegate {
+    private var didFire = false
+    private let handler: (Bool) -> Void
+
+    init(_ handler: @escaping (Bool) -> Void) {
+        self.handler = handler
+        super.init()
+    }
+
+    func animationDidStop(_ animation: CAAnimation, finished: Bool) {
+        guard !didFire else { return }
+        didFire = true
+        handler(finished)
     }
 }
 
@@ -250,6 +276,8 @@ final class SplitFlapPanel {
     func cancelFlip() {
         CATransaction.begin()
         CATransaction.setDisableActions(true)
+        staticTopLayer.removeAllAnimations()
+        staticBottomLayer.removeAllAnimations()
         topFlapContainer.removeAllAnimations()
         bottomFlapContainer.removeAllAnimations()
         applyGlyph(currentCharacter, half: .top,    to: staticTopLayer,      storedIn: \.staticTopCharacter)
@@ -259,6 +287,7 @@ final class SplitFlapPanel {
         topFlapContainer.transform    = CATransform3DIdentity
         bottomFlapContainer.transform = CATransform3DIdentity
         bottomFlapContainer.isHidden  = false
+        bottomFlapContainer.opacity   = 1
         isFlipping = false
         CATransaction.commit()
     }
@@ -282,40 +311,179 @@ final class SplitFlapPanel {
         CATransaction.commit()
     }
 
-    /// Configure layers for the start of a single flip step.
-    func prepareFlip(
-        fromChar: SplitFlapCharacter,
-        toChar: SplitFlapCharacter,
-        revealStaticBottom: Bool = true,
-        batchedTransaction: Bool = false
+    /// Animate a full multi-step flip to `target` entirely on the render
+    /// server. Every intermediate character and both half-flap rotations are
+    /// encoded once as keyframe animations and committed in a single pass, so
+    /// no per-step main-thread work runs while the flip plays. A single
+    /// completion fires when the whole sequence settles.
+    ///
+    /// When `beginTime` is in the future the panel keeps showing its current
+    /// character (its untouched model state) until then — this is how the wave
+    /// sweep staggers without per-panel timers.
+    func flip(
+        to target: SplitFlapCharacter,
+        beginTime: CFTimeInterval,
+        batchedTransaction: Bool,
+        shouldContinue: @escaping () -> Bool,
+        completion: (() -> Void)?
     ) {
-        if batchedTransaction {
-            applyPreparedFlipState(fromChar: fromChar, toChar: toChar, revealStaticBottom: revealStaticBottom)
-            return
+        let steps = currentCharacter.stepsTo(target)
+        guard steps > 0 else { completion?(); return }
+        guard !isFlipping else { completion?(); return }
+
+        // Drum sequence: seq[0] == current, seq[steps] == target.
+        var seq: [SplitFlapCharacter] = [currentCharacter]
+        seq.reserveCapacity(steps + 1)
+        var ch = currentCharacter
+        for _ in 0..<steps {
+            ch = ch.next
+            seq.append(ch)
         }
 
-        CATransaction.begin()
-        CATransaction.setDisableActions(true)
-        applyPreparedFlipState(fromChar: fromChar, toChar: toChar, revealStaticBottom: revealStaticBottom)
-        CATransaction.commit()
+        // Pre-resolve every glyph half the sequence will show. If any surface
+        // is unavailable, fall back to a plain snap so the board still reaches
+        // the target character.
+        var topGlyphs: [Any] = []       // top halves of seq[0...steps]
+        var bottomGlyphs: [Any] = []    // bottom halves of seq[1...steps]
+        topGlyphs.reserveCapacity(steps + 1)
+        bottomGlyphs.reserveCapacity(steps)
+        for (index, character) in seq.enumerated() {
+            guard let top = glyph(character, .top) else {
+                setCharacter(target, animated: false); completion?(); return
+            }
+            topGlyphs.append(top)
+            if index > 0 {
+                guard let bottom = glyph(character, .bottom) else {
+                    setCharacter(target, animated: false); completion?(); return
+                }
+                bottomGlyphs.append(bottom)
+            }
+        }
+
+        beginFlipping()
+
+        let fall  = FlipAnimator.topFallDuration
+        let rise  = FlipAnimator.bottomRiseDuration
+        let pause = FlipAnimator.interStepPause
+        let span  = fall + rise + pause            // one mechanical step
+        let total = Double(steps) * span
+        let kFall = fall / span                     // fraction of a step spent falling
+        let kRise = (fall + rise) / span            // fraction elapsed once risen
+
+        let easeIn  = CAMediaTimingFunction(name: .easeIn)
+        let easeOut = CAMediaTimingFunction(name: .easeOut)
+        let linear  = CAMediaTimingFunction(name: .linear)
+
+        // Top flap: falls 0 -> -90deg (revealing the new top behind it), then
+        // stays folded/edge-on; the per-step jump back to flat is invisible
+        // because the static top already shows the settled character.
+        let topRotation = CAKeyframeAnimation(keyPath: "transform.rotation.x")
+        topRotation.values = [0.0, -Double.pi / 2, -Double.pi / 2, -Double.pi / 2].map { NSNumber(value: $0) }
+        topRotation.keyTimes = [0.0, kFall, kRise, 1.0].map { NSNumber(value: $0) }
+        topRotation.timingFunctions = [easeIn, linear, linear]
+        topRotation.duration = span
+        topRotation.repeatCount = Float(steps)
+
+        // Bottom flap: stays folded during the fall, then rises 90deg -> flat.
+        let bottomRotation = CAKeyframeAnimation(keyPath: "transform.rotation.x")
+        bottomRotation.values = [Double.pi / 2, Double.pi / 2, 0.0, 0.0].map { NSNumber(value: $0) }
+        bottomRotation.keyTimes = [0.0, kFall, kRise, 1.0].map { NSNumber(value: $0) }
+        bottomRotation.timingFunctions = [linear, easeOut, linear]
+        bottomRotation.duration = span
+        bottomRotation.repeatCount = Float(steps)
+
+        // Bottom flap is invisible while folded (during the fall) and visible as
+        // it rises — reproducing the old per-step isHidden toggle with no timer.
+        // Discrete keyTimes need one more entry than values.
+        let bottomOpacity = CAKeyframeAnimation(keyPath: "opacity")
+        bottomOpacity.values = [0.0, 1.0].map { NSNumber(value: $0) }
+        bottomOpacity.keyTimes = [0.0, kFall, 1.0].map { NSNumber(value: $0) }
+        bottomOpacity.calculationMode = .discrete
+        bottomOpacity.duration = span
+        bottomOpacity.repeatCount = Float(steps)
+
+        // Glyph tracks span the whole flip. Top halves advance one character as
+        // each step settles (after the rise); bottom halves show the incoming
+        // character for the full step. Discrete mode => keyTimes = values + 1.
+        var topKeyTimes: [NSNumber] = [NSNumber(value: 0)]
+        topKeyTimes.reserveCapacity(steps + 2)
+        for i in 0..<steps {
+            topKeyTimes.append(NSNumber(value: (Double(i) * span + fall + rise) / total))
+        }
+        topKeyTimes.append(NSNumber(value: 1))
+
+        var bottomKeyTimes: [NSNumber] = [NSNumber(value: 0)]
+        bottomKeyTimes.reserveCapacity(steps + 1)
+        for i in 1..<steps {
+            bottomKeyTimes.append(NSNumber(value: Double(i) * span / total))
+        }
+        bottomKeyTimes.append(NSNumber(value: 1))
+
+        func glyphTrack(_ values: [Any], _ keyTimes: [NSNumber]) -> CAKeyframeAnimation {
+            let track = CAKeyframeAnimation(keyPath: "contents")
+            track.values = values
+            track.keyTimes = keyTimes
+            track.calculationMode = .discrete
+            track.duration = total
+            return track
+        }
+
+        // The top-flap glyph track spans the full duration and anchors the
+        // single completion callback for the whole flip.
+        let topFlapTrack = glyphTrack(topGlyphs, topKeyTimes)
+        topFlapTrack.delegate = FlipCompletionDelegate { [weak self] finished in
+            guard let self = self else { return }
+            guard finished, shouldContinue() else { completion?(); return }
+            self.concludeFlip(to: target)
+            completion?()
+        }
+
+        let tracks: [(CALayer, String, CAKeyframeAnimation)] = [
+            (staticTopLayer,      "flipTopGlyph",    glyphTrack(topGlyphs, topKeyTimes)),
+            (staticBottomLayer,   "flipBottomGlyph", glyphTrack(bottomGlyphs, bottomKeyTimes)),
+            (topFlapContainer,    "flipRotation",    topRotation),
+            (topFlapContainer,    "flipTopGlyph",    topFlapTrack),
+            (bottomFlapContainer, "flipRotation",    bottomRotation),
+            (bottomFlapContainer, "flipOpacity",     bottomOpacity),
+            (bottomFlapContainer, "flipBottomGlyph", glyphTrack(bottomGlyphs, bottomKeyTimes)),
+        ]
+
+        if !batchedTransaction {
+            CATransaction.begin()
+            CATransaction.setDisableActions(true)
+        }
+        for (layer, key, anim) in tracks {
+            anim.beginTime = beginTime
+            anim.fillMode = .forwards           // hold the settled state until concludeFlip
+            anim.isRemovedOnCompletion = false
+            layer.add(anim, forKey: key)
+        }
+        if !batchedTransaction {
+            CATransaction.commit()
+        }
     }
 
-    private func applyPreparedFlipState(
-        fromChar: SplitFlapCharacter,
-        toChar: SplitFlapCharacter,
-        revealStaticBottom: Bool
-    ) {
-        applyGlyph(fromChar, half: .top,    to: staticTopLayer,      storedIn: \.staticTopCharacter)
-        applyGlyph(revealStaticBottom ? toChar : fromChar,
-                   half: .bottom, to: staticBottomLayer, storedIn: \.staticBottomCharacter)
-        applyGlyph(fromChar, half: .top,    to: topFlapContainer,    storedIn: \.topFlapCharacter)
-        applyGlyph(toChar,   half: .bottom, to: bottomFlapContainer, storedIn: \.bottomFlapCharacter)
-        topFlapContainer.transform    = CATransform3DIdentity        // flat, visible
-        bottomFlapContainer.transform = CATransform3DMakeRotation(.pi / 2, 1, 0, 0)
-        bottomFlapContainer.isHidden  = true  // invisible until top flap finishes
+    private func glyph(_ character: SplitFlapCharacter, _ half: GlyphImageCache.Half) -> Any? {
+        GlyphImageCache.shared.contents(
+            for: character,
+            panelSize: CGSize(width: w, height: h),
+            scale: contentsScale,
+            half: half
+        )
     }
 
-    /// Called after a single flip step completes to snap to the final state.
+    /// Settle the panel onto its final character and drop the flip animations
+    /// in one transaction so the presentation never flickers back to the model.
+    private func concludeFlip(to char: SplitFlapCharacter) {
+        staticTopLayer.removeAllAnimations()
+        staticBottomLayer.removeAllAnimations()
+        topFlapContainer.removeAllAnimations()
+        bottomFlapContainer.removeAllAnimations()
+        finalizeFlip(to: char, done: true)
+    }
+
+    /// Snap the panel's model state to its final character. Called once when a
+    /// flip settles (and reused to reset state elsewhere).
     func finalizeFlip(to char: SplitFlapCharacter, done: Bool) {
         currentCharacter = char
         CATransaction.begin()
@@ -327,6 +495,7 @@ final class SplitFlapPanel {
         topFlapContainer.transform    = CATransform3DIdentity
         bottomFlapContainer.transform = CATransform3DIdentity
         bottomFlapContainer.isHidden  = false
+        bottomFlapContainer.opacity   = 1
         if done {
             isFlipping = false
         }


### PR DESCRIPTION
## Summary

Makes the screensaver near-idle on the CPU by moving the flip animation off the main thread and onto the render server — the model Apple's shipped screensavers use.

**The problem.** `FlipAnimator` scheduled main-thread work for *every* character step of *every* flip: a `DispatchQueue.main.asyncAfter` to reveal the bottom flap, a `CATransaction` completion to finalize the step, and another `asyncAfter` to chain the next step. A random transition averages ~23 steps, and the wave phase animates hundreds of panels at once, so the app woke its main thread thousands of times per second to babysit animations the render server was already drawing. That kept it at the top of Activity Monitor even while the machine was in use.

**The fix.** `SplitFlapPanel.flip(...)` now encodes the entire mechanical sequence up front — every intermediate glyph and both half-flap rotations — as a single batch of `CAKeyframeAnimation`s committed in one pass. Core Animation plays the whole timeline on the window server with no per-step app involvement; a single `CAAnimationDelegate` callback settles the model state when the flip finishes. Per-flip main-thread wakeups drop from ~3 × steps to exactly one. The mechanical look is preserved (same fall/rise/pause timing, same drum spin through every intermediate character).

### Files touched

- `SplitFlapPanel.swift` — new `flip()` builds the multi-step flip as keyframe tracks (two rotations, a discrete opacity track for bottom-flap visibility, discrete glyph tracks for both halves); one completion via `FlipCompletionDelegate`; glyph cache keyed by a packed integer instead of an interpolated string.
- `FlipAnimator.swift` — reduced to a thin orchestrator over `panel.flip()`; the per-step `asyncAfter` chain is gone.
- `DisplayClock.swift` — idle ticks add a tick's flips inside one `CATransaction` (one render-server commit per tick instead of up to twelve).

## Governing Issue

No issue is linked — this is a direct response to a maintainer performance report ("resource hog, top of Activity Monitor"). Happy to open a tracking issue if preferred.

## Validation

- [ ] Not run locally — this session is a Linux container with no Swift/Xcode toolchain, so the `ScreenSaver` / Core Animation target cannot be compiled or visually exercised here. The `macOS Checks` CI job (`xcodebuild`) is the compile gate and runs now that this PR is ready for review.
- Reviewed by hand: the keyframe choreography reproduces the previous per-step state transitions; resting state is authoritatively re-applied on completion so the board is always correct between flips; cancel/resize paths clear every animated layer.
- Please confirm the animation looks right on a real Mac (idle drift + a full wave) — I could not see it run.

One intentional nuance: during a wave a panel reveals its incoming bottom-half glyph at its scheduled begin time rather than ~75 ms later as the flap rises (the idle path already behaved this way; this unifies them). Imperceptible against a board full of spinning characters.

## Bootstrap Governance

No bootstrap-managed files, governance, or CI policy touched. `CI Gate` remains the single required check; the `run-fast-checks.sh` guardrails still hold (no `asyncAfter` in `DisplayClock`, IOSurface glyphs preserved, layer-preserving resize intact).

## Merge Automation

Auto-merge is enabled by JT. `CI Gate` remains the required merge check, and `macOS Checks` is the compile validation surface for this Swift/ScreenSaver change. Once the fresh CI run is green, the PR should be ready for the armed auto-merge path.

## Notes

- No behavior or config flags added; timing constants and the character drum are unchanged.
- Render-server batching lets the app process sleep mid-flip — the intended Apple-grade idle profile.

https://claude.ai/code/session_01PG6hMRB5mQWU9xpLuq8m9U
