### PR TITLE
Reconcile bootstrap release governance

### DIFF
--- a/.github/workflows/extended-validation.yml
+++ b/.github/workflows/extended-validation.yml
@@ -25,7 +25,7 @@ defaults:
 jobs:
   changes:
     name: Detect Extended Validation Scope
-    runs-on: ['self-hosted', 'synology', 'shell-only', 'public']
+    runs-on: ['self-hosted', 'linux', 'shell-only', 'public']
     outputs:
       app: ${{ steps.preset.outputs.app || steps.filter.outputs.app || 'false' }}
       ci: ${{ steps.preset.outputs.ci || steps.filter.outputs.ci || 'false' }}
@@ -81,7 +81,7 @@ jobs:
 
   fast-checks:
     name: Fast Checks
-    runs-on: ['self-hosted', 'synology', 'shell-only', 'public']
+    runs-on: ['self-hosted', 'linux', 'shell-only', 'public']
     timeout-minutes: 15
     needs: changes
     if: needs.changes.outputs.app == 'true' || needs.changes.outputs.ci == 'true'
@@ -93,7 +93,7 @@ jobs:
 
   extended-checks:
     name: Extended Checks
-    runs-on: ['self-hosted', 'synology', 'shell-only', 'public']
+    runs-on: ['self-hosted', 'linux', 'shell-only', 'public']
     timeout-minutes: 20
     needs: changes
     if: needs.changes.outputs.extended == 'true' || needs.changes.outputs.app == 'true'
@@ -105,7 +105,7 @@ jobs:
 
   validate-secrets:
     name: Validate Secrets
-    runs-on: ['self-hosted', 'synology', 'shell-only', 'public']
+    runs-on: ['self-hosted', 'linux', 'shell-only', 'public']
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
@@ -114,7 +114,7 @@ jobs:
 
   extended-validation-gate:
     name: Extended Validation Gate
-    runs-on: ['self-hosted', 'synology', 'shell-only', 'public']
+    runs-on: ['self-hosted', 'linux', 'shell-only', 'public']
     if: always()
     needs:
       - changes

--- a/.github/workflows/extended-validation.yml
+++ b/.github/workflows/extended-validation.yml
@@ -96,12 +96,31 @@ jobs:
     runs-on: ['self-hosted', 'linux', 'shell-only', 'public']
     timeout-minutes: 20
     needs: changes
-    if: needs.changes.outputs.extended == 'true' || needs.changes.outputs.app == 'true'
+    if: needs.changes.outputs.extended == 'true'
     steps:
       - uses: actions/checkout@v4
 
       - name: Run extended validation
         run: bash scripts/ci/run-extended-validation.sh
+
+  macos-checks:
+    name: macOS Checks
+    runs-on: ['self-hosted', 'private', 'macOS', 'ARM64', 'xcode']
+    timeout-minutes: 20
+    needs: changes
+    if: needs.changes.outputs.app == 'true'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run macOS validation
+        run: |
+          xcodebuild \
+            -project SplitFlap.xcodeproj \
+            -scheme SplitFlap \
+            -configuration Release \
+            -derivedDataPath build \
+            ONLY_ACTIVE_ARCH=NO \
+            build
 
   validate-secrets:
     name: Validate Secrets
@@ -120,6 +139,7 @@ jobs:
       - changes
       - fast-checks
       - extended-checks
+      - macos-checks
       - validate-secrets
     steps:
       - name: Check extended validation jobs
@@ -128,6 +148,7 @@ jobs:
             changes=${{ needs.changes.result }}
             fast-checks=${{ needs.fast-checks.result }}
             extended-checks=${{ needs.extended-checks.result }}
+            macos-checks=${{ needs.macos-checks.result }}
             validate-secrets=${{ needs.validate-secrets.result }}
         run: |
           failed=0

--- a/.github/workflows/pr-fast-ci.yml
+++ b/.github/workflows/pr-fast-ci.yml
@@ -84,7 +84,7 @@ jobs:
     needs: changes
     if: >-
       github.event.pull_request.draft == false &&
-      needs.changes.outputs.apple == 'true'
+      (needs.changes.outputs.apple == 'true' || needs.changes.outputs.ci == 'true')
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/pr-fast-ci.yml
+++ b/.github/workflows/pr-fast-ci.yml
@@ -10,7 +10,6 @@ concurrency:
 
 permissions:
   contents: read
-  pull-requests: read
 
 env:
   NODE_VERSION: '20'
@@ -23,11 +22,10 @@ defaults:
 jobs:
   changes:
     name: Detect Relevant Changes
-    runs-on: ['self-hosted', 'synology', 'shell-only', 'public']
+    runs-on: ['self-hosted', 'linux', 'shell-only', 'public']
     outputs:
       app: ${{ steps.filter.outputs.app }}
       ci: ${{ steps.filter.outputs.ci }}
-      apple: ${{ steps.filter.outputs.apple }}
     steps:
       - uses: dorny/paths-filter@v3
         id: filter
@@ -57,13 +55,10 @@ jobs:
               - 'docs/bootstrap/**'
               - '.env.example'
               - 'CODEOWNERS'
-            apple:
-              - 'SplitFlap/**'
-              - 'SplitFlap.xcodeproj/**'
 
   fast-checks:
     name: Fast Checks
-    runs-on: ['self-hosted', 'synology', 'shell-only', 'public']
+    runs-on: ['self-hosted', 'linux', 'shell-only', 'public']
     timeout-minutes: 15
     needs: changes
     if: >-
@@ -77,34 +72,9 @@ jobs:
       - name: Run fast checks
         run: bash scripts/ci/run-fast-checks.sh
 
-
-  macos-checks:
-    name: macOS Checks
-    runs-on: ['self-hosted', 'private', 'macOS', 'ARM64', 'xcode']
-    timeout-minutes: 15
-    needs: changes
-    if: >-
-      github.event.pull_request.draft == false &&
-      needs.changes.outputs.apple == 'true'
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: Run macOS validation
-        run: |
-          xcodebuild \
-            -project SplitFlap.xcodeproj \
-            -scheme SplitFlap \
-            -configuration Release \
-            -derivedDataPath build \
-            ONLY_ACTIVE_ARCH=NO \
-            build
-
-
   validate-pr-description:
     name: Validate PR Description
-    runs-on: ['self-hosted', 'synology', 'shell-only', 'public']
+    runs-on: ['self-hosted', 'linux', 'shell-only', 'public']
     timeout-minutes: 5
     if: github.event.pull_request.draft == false
     env:
@@ -154,7 +124,7 @@ jobs:
 
   validate-secrets:
     name: Validate Secrets
-    runs-on: ['self-hosted', 'synology', 'shell-only', 'public']
+    runs-on: ['self-hosted', 'linux', 'shell-only', 'public']
     timeout-minutes: 10
     if: github.event.pull_request.draft == false
     steps:
@@ -166,13 +136,12 @@ jobs:
 
   ci-gate:
     name: CI Gate
-    runs-on: ['self-hosted', 'synology', 'shell-only', 'public']
+    runs-on: ['self-hosted', 'linux', 'shell-only', 'public']
     if: always()
     needs:
       - changes
       - fast-checks
       - validate-pr-description
-      - macos-checks
       - validate-secrets
     steps:
       - name: Check required PR jobs
@@ -181,7 +150,6 @@ jobs:
             changes=${{ needs.changes.result }}
             fast-checks=${{ needs.fast-checks.result }}
             validate-pr-description=${{ needs.validate-pr-description.result }}
-            macos-checks=${{ needs.macos-checks.result }}
             validate-secrets=${{ needs.validate-secrets.result }}
         run: |
           failed=0

--- a/.github/workflows/pr-fast-ci.yml
+++ b/.github/workflows/pr-fast-ci.yml
@@ -10,6 +10,7 @@ concurrency:
 
 permissions:
   contents: read
+  pull-requests: read
 
 env:
   NODE_VERSION: '20'
@@ -26,6 +27,7 @@ jobs:
     outputs:
       app: ${{ steps.filter.outputs.app }}
       ci: ${{ steps.filter.outputs.ci }}
+      apple: ${{ steps.filter.outputs.apple }}
     steps:
       - uses: dorny/paths-filter@v3
         id: filter
@@ -55,6 +57,9 @@ jobs:
               - 'docs/bootstrap/**'
               - '.env.example'
               - 'CODEOWNERS'
+            apple:
+              - 'SplitFlap/**'
+              - 'SplitFlap.xcodeproj/**'
 
   fast-checks:
     name: Fast Checks
@@ -71,6 +76,29 @@ jobs:
 
       - name: Run fast checks
         run: bash scripts/ci/run-fast-checks.sh
+
+  macos-checks:
+    name: macOS Checks
+    runs-on: ['self-hosted', 'private', 'macOS', 'ARM64', 'xcode']
+    timeout-minutes: 15
+    needs: changes
+    if: >-
+      github.event.pull_request.draft == false &&
+      needs.changes.outputs.apple == 'true'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Run macOS validation
+        run: |
+          xcodebuild \
+            -project SplitFlap.xcodeproj \
+            -scheme SplitFlap \
+            -configuration Release \
+            -derivedDataPath build \
+            ONLY_ACTIVE_ARCH=NO \
+            build
 
   validate-pr-description:
     name: Validate PR Description
@@ -141,6 +169,7 @@ jobs:
     needs:
       - changes
       - fast-checks
+      - macos-checks
       - validate-pr-description
       - validate-secrets
     steps:
@@ -149,6 +178,7 @@ jobs:
           RESULTS: >-
             changes=${{ needs.changes.result }}
             fast-checks=${{ needs.fast-checks.result }}
+            macos-checks=${{ needs.macos-checks.result }}
             validate-pr-description=${{ needs.validate-pr-description.result }}
             validate-secrets=${{ needs.validate-secrets.result }}
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 .claude/
+.derivedData/
 build/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 - Always work on a feature branch. Hooks block commits to `main` and `master`; enable them with `git config core.hooksPath .githooks`.
 - Stack baseline: Generic polyglot.
 - CI baseline: fast PR checks stay cheap and shell-safe; extended validation runs on `main`, nightly, or manual dispatch.
-- Self-hosted runner policy: shell-safe jobs may use `[self-hosted, synology, shell-only, public]`; anything needing Docker, service containers, browser infra, or `container:` must stay on GitHub-hosted runners.
+- Self-hosted runner policy: shell-safe jobs must use `[self-hosted, linux, shell-only, public]`; native repos must use self-hosted runners for required automation, with Docker, service-container, browser, or `container:` workloads routed to dedicated self-hosted capability pools.
 - Add or update tests for every interactive, branching, or operator-facing behavior change.
 - PRs must use the generated pull request template. The required PR gate validates summary, issue linkage, validation evidence, and risk notes.
 - Never commit real secrets, runtime auth, or machine-local env files. Use templates and GitHub environments instead.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,1 @@
-# Managed CODEOWNERS for OMT-Global native repos.
-* @pheidon @jmcte
+* @jmcte

--- a/docs/bootstrap/onboarding.md
+++ b/docs/bootstrap/onboarding.md
@@ -27,8 +27,8 @@ Use this checklist after the first bootstrap render or whenever `project.bootstr
 
 ## Runner Policy
 
-- Shell-safe jobs may use `[self-hosted, synology, shell-only, public]`.
-- Docker, service-container, browser, and `container:` workloads stay on GitHub-hosted runners.
+- Shell-safe jobs must use `[self-hosted, linux, shell-only, public]`.
+- Native repos must use self-hosted runners for required automation; Docker, service-container, browser, and `container:` workloads require a dedicated self-hosted runner pool with matching capability labels.
 - Keep PR checks cheap. Add heavy validation to `scripts/ci/run-extended-validation.sh` instead of the PR lane.
 
 - Consume shared security, release, and AI attestation workflows from the control-plane repo once those contracts are pinned for production use.

--- a/docs/bootstrap/versioning.md
+++ b/docs/bootstrap/versioning.md
@@ -20,5 +20,29 @@ Consumers should prefer `v1` for the default compatibility channel, `v1.2` when 
 
 - `.github/workflows/release-tag.yml` runs when an exact SemVer tag matching `v*.*.*` is pushed.
 - `scripts/ci/run-release-verification.sh` runs the repo release gate before publication.
+- `scripts/ci/run-release-version.sh` validates that the repo version surfaces match the pushed tag before build and publish.
+- `scripts/ci/run-release-build.sh` populates the release artifact directory and writes SHA256 checksums when enabled.
 - `scripts/ci/run-release-publish.sh` is the repo hook for artifact publication; the generated default is a no-op until the repo needs more than GitHub releases.
 - The shared reusable release workflow creates or updates the GitHub release and then advances the floating compatibility tags when enabled in `project.bootstrap.yaml`.
+
+## Version Validation
+
+- Version bumps land in a normal pull request before the release tag is pushed; the workflow never creates post-tag commits.
+- Configure version surfaces under `release.versions` in `project.bootstrap.yaml` with a `type` of `npm`, `python`, or `container` and the file `path`.
+- `scripts/ci/run-release-version.sh` fails the release when a configured `package.json` or `pyproject.toml` version does not equal the tag (with the `v` prefix stripped). Container surfaces are derived from the tag at publish time.
+- With no configured surfaces the hook prints an explicit no-op rather than silently passing.
+
+## Release Artifacts
+
+- The default release artifact directory is `dist/release/`.
+- `scripts/ci/run-release-build.sh` is where repo-specific build steps populate that directory; with no artifacts it prints an explicit no-op message instead of failing silently.
+- Checksum generation is `sha256`; when set to `sha256` a `SHA256SUMS` file is written alongside the artifacts.
+- The reusable workflow uploads every file in the artifact directory to the GitHub Release.
+- SBOM/provenance is `optional` and is designed into the manifest for repos that opt in.
+
+## Release Notes
+
+- Release notes are generated automatically for every exact tag from changes since the previous exact SemVer tag.
+- The default implementation uses GitHub generated notes; `.github/release.yml` maps bootstrap labels to categories.
+- Override categories under `release.changelog.categories` in `project.bootstrap.yaml`. The default categories are Features, Fixes, Operations, and Documentation, with everything else under Other Changes.
+- The reusable workflow writes the notes to `dist/release/RELEASE_NOTES.md` before creating the GitHub Release.

--- a/project.bootstrap.yaml
+++ b/project.bootstrap.yaml
@@ -288,12 +288,40 @@ ci:
     reusableWorkflowRef: refs/heads/main
 release:
   enabled: true
+  maturity: simple
   tagPrefix: v
   createGitHubRelease: true
   updateMajorTag: true
   updateMinorTag: true
   reusableWorkflowRepo: OMT-Global/bootstrap
   reusableWorkflowRef: refs/heads/main
+  changelog:
+    enabled: true
+    mode: github-generated-notes
+    categories:
+      - title: Features
+        labels:
+          - type:feature
+      - title: Fixes
+        labels:
+          - type:bug
+      - title: Operations
+        labels:
+          - area:infra
+          - area:qa
+      - title: Documentation
+        labels:
+          - kind:docs
+          - documentation
+  versions: []
+  artifacts:
+    directory: dist/release
+    checksum: sha256
+    sbom: optional
+  publish:
+    githubReleaseAssets: true
+    packages: []
+    containers: []
 agents:
   manageCodexHome: true
   codexProfile: default

--- a/scripts/check-detect-secrets.sh
+++ b/scripts/check-detect-secrets.sh
@@ -52,6 +52,7 @@
       'AKIA[0-9A-Z]{16}'
       'BEGIN (RSA|OPENSSH|EC) PRIVATE KEY'
       'OPENAI_API_KEY='
+      'ANTHROPIC_API_KEY='
       'SUDO_PASS='
       'BW_SESSION='
     )

--- a/scripts/ci/run-release-build.sh
+++ b/scripts/ci/run-release-build.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+artifact_dir="dist/release"
+mkdir -p "${artifact_dir}"
+
+# Add repo-specific build steps above this line to populate ${artifact_dir}
+# with downloadable release assets before checksums are generated.
+
+mapfile -t artifacts < <(find "${artifact_dir}" -maxdepth 1 -type f ! -name SHA256SUMS | sort)
+if [[ ${#artifacts[@]} -eq 0 ]]; then
+  echo "No release artifacts were produced in ${artifact_dir}."
+  echo "This repo ships no downloadable assets; add build steps to scripts/ci/run-release-build.sh when it does."
+  exit 0
+fi
+(
+  cd "${artifact_dir}"
+  : > SHA256SUMS
+  for entry in "${artifacts[@]}"; do
+    sha256sum -- "${entry#"${artifact_dir}/"}" >> SHA256SUMS
+  done
+)
+echo "Wrote ${artifact_dir}/SHA256SUMS for ${#artifacts[@]} artifact(s)."

--- a/scripts/ci/run-release-version.sh
+++ b/scripts/ci/run-release-version.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tag="${GITHUB_REF_NAME:-}"
+if [[ -z "${tag}" ]]; then
+  echo "GITHUB_REF_NAME is required to validate release versions." >&2
+  exit 1
+fi
+prefix="v"
+version="${tag#"${prefix}"}"
+
+echo "No release version surfaces are configured in project.bootstrap.yaml."
+echo "Skipping version validation for ${tag}; version bump pull requests must merge before the release tag is pushed."


### PR DESCRIPTION
## Summary

- Reconcile Screensaver repo-local bootstrap-managed workflows and governance files.
- Add generated release build/version helper scripts.
- Refresh bootstrap release/versioning documentation and manifest release policy.
- Restore required macOS/Xcode validation for app and CI/governance changes that affect the validation path.

## Governing Issue

- No governing issue is linked. This is maintenance cleanup from the Codex configuration/worktree hygiene pass.

## Validation

- [x] `git diff --check origin/main...HEAD`
- [x] `bash -n scripts/ci/run-release-build.sh`
- [x] `bash -n scripts/ci/run-release-version.sh`
- [x] `xcodebuild -project SplitFlap.xcodeproj -scheme SplitFlap -configuration Release -derivedDataPath build ONLY_ACTIVE_ARCH=NO build`
- [x] GitHub PR Fast CI on head `8d7ce6b`: `Fast Checks`, `macOS Checks`, `Validate PR Description`, `Validate Secrets`, and `CI Gate` passed.

## Bootstrap Governance

- Applied repo-local bootstrap output only with `bootstrap apply repo`.
- GitHub settings were not applied.
- Home-profile changes were not applied.

## Merge Automation

- Auto-merge is not enabled because maintainer review is still required.
- Use fallback merge-readiness: required checks pass or are intentionally skipped, review is satisfied, and no blocking review state remains.

## Notes

- No application runtime code changed.
- The branch was rebased onto current `origin/main` after PR creation to resolve generated workflow conflicts.
- `macOS Checks` now runs for Apple source/project changes and CI/governance changes, so workflow/script/bootstrap changes cannot bypass native validation through the Linux-only lane.
