### PR TITLE
Reduce idle screensaver CPU usage

### DIFF
--- a/SplitFlap/DisplayClock.swift
+++ b/SplitFlap/DisplayClock.swift
@@ -10,6 +10,7 @@ private protocol DisplayTicker: AnyObject {
 @available(macOS 14.0, *)
 private final class CADisplayTicker: NSObject, DisplayTicker {
     private var link: CADisplayLink?
+    private var isInvalidated = false
     private let onFrame: (CFTimeInterval) -> Void
 
     init?(screen: NSScreen?, onFrame: @escaping (CFTimeInterval) -> Void) {
@@ -32,17 +33,20 @@ private final class CADisplayTicker: NSObject, DisplayTicker {
     }
 
     func invalidate() {
+        isInvalidated = true
         link?.invalidate()
         link = nil
     }
 
     @objc private func tick(_ link: CADisplayLink) {
+        guard !isInvalidated else { return }
         onFrame(link.targetTimestamp > 0 ? link.targetTimestamp : link.timestamp)
     }
 }
 
 private final class CVDisplayTicker: DisplayTicker {
     private var link: CVDisplayLink?
+    private var isInvalidated = false
     private let onFrame: (CFTimeInterval) -> Void
 
     init?(onFrame: @escaping (CFTimeInterval) -> Void) {
@@ -66,7 +70,8 @@ private final class CVDisplayTicker: DisplayTicker {
             } else {
                 timestamp = CACurrentMediaTime()
             }
-            DispatchQueue.main.async {
+            DispatchQueue.main.async { [weak ticker] in
+                guard let ticker, !ticker.isInvalidated else { return }
                 ticker.onFrame(timestamp)
             }
             return kCVReturnSuccess
@@ -75,6 +80,7 @@ private final class CVDisplayTicker: DisplayTicker {
     }
 
     func invalidate() {
+        isInvalidated = true
         if let link {
             CVDisplayLinkStop(link)
         }
@@ -99,6 +105,7 @@ final class DisplayClock: NSObject {
     private var lastIdleTickTimestamp: CFTimeInterval?
     private var phase: Phase = .idle
     private var phaseTickCount: Int = 0
+    private var isRunning = false
 
     private enum Phase {
         case idle       // random individual flips
@@ -130,15 +137,20 @@ final class DisplayClock: NSObject {
     func start(screen: NSScreen? = NSScreen.main) {
         stop()
         runGeneration += 1
+        isRunning = true
         phase = .idle
         phaseTickCount = 0
         lastIdleTickTimestamp = nil
 
         ticker = makeTicker(screen: screen)
+        if ticker == nil {
+            isRunning = false
+        }
     }
 
     func stop() {
         runGeneration += 1
+        isRunning = false
         ticker?.invalidate()
         ticker = nil
         lastIdleTickTimestamp = nil
@@ -166,6 +178,7 @@ final class DisplayClock: NSObject {
     }
 
     private func displayTick(timestamp: CFTimeInterval) {
+        guard isRunning else { return }
         guard let last = lastIdleTickTimestamp else {
             lastIdleTickTimestamp = timestamp
             return

--- a/SplitFlap/SplitFlapView.swift
+++ b/SplitFlap/SplitFlapView.swift
@@ -10,6 +10,9 @@ final class SplitFlapView: ScreenSaverView {
     private var grid: CharacterGrid?
     private var clock: DisplayClock?
     private var rootLayer: CALayer!
+    private var observedWindow: NSWindow?
+    private var windowObservers: [NSObjectProtocol] = []
+    private var isClockRunning = false
 
     // MARK: - Init
 
@@ -41,19 +44,27 @@ final class SplitFlapView: ScreenSaverView {
         clock = DisplayClock(grid: g)
 
         // Do NOT use animateOneFrame() timer — all animation is CAAnimation-driven.
-        animationTimeInterval = 1.0 / 30.0  // satisfies framework requirement; effectively unused
+        animationTimeInterval = 60.0  // keep ScreenSaverView's empty framework timer cold
+    }
+
+    deinit {
+        removeWindowObservers()
+        clock?.stop()
     }
 
     // MARK: - Lifecycle
 
     override func startAnimation() {
         super.startAnimation()
-        clock?.start(screen: window?.screen ?? NSScreen.main)
+        updateClockForVisibility()
+        DispatchQueue.main.async { [weak self] in
+            self?.updateClockForVisibility()
+        }
     }
 
     override func stopAnimation() {
         super.stopAnimation()
-        clock?.stop()
+        stopClock()
     }
 
     // animateOneFrame is called by ScreenSaverView's built-in timer.
@@ -69,8 +80,15 @@ final class SplitFlapView: ScreenSaverView {
         let scale = NSScreen.main?.backingScaleFactor ?? 2.0
         rootLayer.frame = bounds
         grid?.rebuild(bounds: bounds, isPreview: isPreview, scale: scale)
-        if isAnimating {
-            clock?.start(screen: window?.screen ?? NSScreen.main)
+        updateClockForVisibility(restartIfRunning: true)
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        observeCurrentWindow()
+        updateClockForVisibility()
+        DispatchQueue.main.async { [weak self] in
+            self?.updateClockForVisibility()
         }
     }
 
@@ -80,4 +98,60 @@ final class SplitFlapView: ScreenSaverView {
 
     override var hasConfigureSheet: Bool { false }
     override var configureSheet: NSWindow? { nil }
+
+    private func observeCurrentWindow() {
+        guard observedWindow !== window else { return }
+        removeWindowObservers()
+        observedWindow = window
+
+        guard let window else { return }
+        let center = NotificationCenter.default
+        let notifications: [NSNotification.Name] = [
+            NSWindow.didChangeOcclusionStateNotification,
+            NSWindow.didMiniaturizeNotification,
+            NSWindow.didDeminiaturizeNotification
+        ]
+
+        windowObservers = notifications.map { name in
+            center.addObserver(
+                forName: name,
+                object: window,
+                queue: .main
+            ) { [weak self] _ in
+                self?.updateClockForVisibility()
+            }
+        }
+    }
+
+    private func removeWindowObservers() {
+        let center = NotificationCenter.default
+        windowObservers.forEach { center.removeObserver($0) }
+        windowObservers = []
+        observedWindow = nil
+    }
+
+    private var shouldRunClock: Bool {
+        guard isAnimating, let window else { return false }
+        return window.isVisible
+            && !window.isMiniaturized
+            && window.occlusionState.contains(.visible)
+    }
+
+    private func updateClockForVisibility(restartIfRunning: Bool = false) {
+        guard shouldRunClock else {
+            stopClock()
+            return
+        }
+
+        if restartIfRunning || !isClockRunning {
+            clock?.start(screen: window?.screen ?? NSScreen.main)
+            isClockRunning = true
+        }
+    }
+
+    private func stopClock() {
+        guard isClockRunning else { return }
+        clock?.stop()
+        isClockRunning = false
+    }
 }


### PR DESCRIPTION
## Summary
- Stop the split-flap display clock unless the saver is animating in a visible, unminiaturized, non-occluded window.
- Cool ScreenSaverView's unused empty framework timer from 30 Hz to one wakeup per minute because Core Animation and DisplayClock drive the real animation.
- Ignore stale CADisplayLink and CVDisplayLink callbacks after invalidation so stopped saver instances do not resume tick work from queued callbacks.

## Governing Issue
No governing issue is linked. This was requested directly by the maintainer in Codex because SplitFlap appeared to consume CPU even when the screensaver was not active.

## Validation
- [x] `bash scripts/ci/run-fast-checks.sh` - passed on 2026-06-18 with Release xcodebuild success.
- [x] `xcodebuild -project SplitFlap.xcodeproj -scheme SplitFlap -configuration Debug -derivedDataPath build build` - passed on 2026-06-18.

## Bootstrap Governance
- No bootstrap, profile, runner, or repository governance assets changed.
- Runtime source changes are limited to `SplitFlap/DisplayClock.swift` and `SplitFlap/SplitFlapView.swift`.

## Merge Automation
Auto-merge is unsafe until live GitHub required checks complete and maintainer review is satisfied. Use the fallback merge-readiness policy once required checks pass, conversations are resolved, and no blocking review state remains.

## Notes
- No test target exists in this project, so validation is build based.
- Local untracked `.derivedData/` was left untouched and is not part of this PR.
