### PR TITLE
Add configurable SplitFlap display options

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,23 @@ make uninstall
 1. Open **System Settings → Screen Saver**
 2. Select **SplitFlap** from the list
 
+## Configure
+
+Open the SplitFlap options sheet from System Settings to choose what the board
+displays:
+
+- **Display**: random board, custom messages, clock, or date
+- **Messages**: one message per line, including Unicode text and emoji
+- **Message order**: sequential or random
+- **Wave interval**: how often the board updates
+- **Idle shuffle**: whether panels drift between coordinated waves
+- **Board rows**: approximate display density
+- **Theme**: classic amber, terminal green, or monochrome
+
+The original split-flap alphabet still animates through a mechanical forward
+drum sequence. Other Unicode grapheme clusters render directly as valid panel
+targets.
+
 ---
 
 ## Project structure
@@ -76,4 +93,3 @@ make uninstall
 ## Part of [OMT Global](https://github.com/omt-global)
 
 A father-and-son open-source project.
-

--- a/SplitFlap.xcodeproj/project.pbxproj
+++ b/SplitFlap.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		E422C254DE334797B873E101 /* FlipAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F02920C52D74E98859D8ACB /* FlipAnimator.swift */; };
 		D46314B140D444D8BF002D50 /* DisplayClock.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFF542687ECF4850AEE45CBE /* DisplayClock.swift */; };
 		EFE3F48231454D52A4EE2C48 /* CharacterSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = D30537C46A0D417DA9A7C58E /* CharacterSet.swift */; };
+		9B6F9B6C67454D6DA1F7A501 /* SplitFlapConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B6F9B6B67454D6DA1F7A501 /* SplitFlapConfiguration.swift */; };
+		9B6F9B6E67454D6DA1F7A501 /* SplitFlapConfigureSheetController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B6F9B6D67454D6DA1F7A501 /* SplitFlapConfigureSheetController.swift */; };
 		379902B659FA4434815BF2AC /* ScreenSaver.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F729CEFDADDD4F1894EB15A3 /* ScreenSaver.framework */; };
 		E20F4AC790D1441481FB41D6 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 143537C2844D4FCFBBC9CC36 /* QuartzCore.framework */; };
 /* End PBXBuildFile section */
@@ -24,6 +26,8 @@
 		4F02920C52D74E98859D8ACB /* FlipAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlipAnimator.swift; sourceTree = "<group>"; };
 		FFF542687ECF4850AEE45CBE /* DisplayClock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayClock.swift; sourceTree = "<group>"; };
 		D30537C46A0D417DA9A7C58E /* CharacterSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CharacterSet.swift; sourceTree = "<group>"; };
+		9B6F9B6B67454D6DA1F7A501 /* SplitFlapConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplitFlapConfiguration.swift; sourceTree = "<group>"; };
+		9B6F9B6D67454D6DA1F7A501 /* SplitFlapConfigureSheetController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplitFlapConfigureSheetController.swift; sourceTree = "<group>"; };
 		6DF5732666934A6D8D48E527 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		F729CEFDADDD4F1894EB15A3 /* ScreenSaver.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ScreenSaver.framework; path = System/Library/Frameworks/ScreenSaver.framework; sourceTree = SDKROOT; };
 		143537C2844D4FCFBBC9CC36 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
@@ -61,6 +65,8 @@
 				4F02920C52D74E98859D8ACB /* FlipAnimator.swift */,
 				FFF542687ECF4850AEE45CBE /* DisplayClock.swift */,
 				D30537C46A0D417DA9A7C58E /* CharacterSet.swift */,
+				9B6F9B6B67454D6DA1F7A501 /* SplitFlapConfiguration.swift */,
+				9B6F9B6D67454D6DA1F7A501 /* SplitFlapConfigureSheetController.swift */,
 				6DF5732666934A6D8D48E527 /* Info.plist */,
 			);
 			path = SplitFlap;
@@ -152,6 +158,8 @@
 				E422C254DE334797B873E101 /* FlipAnimator.swift in Sources */,
 				D46314B140D444D8BF002D50 /* DisplayClock.swift in Sources */,
 				EFE3F48231454D52A4EE2C48 /* CharacterSet.swift in Sources */,
+				9B6F9B6C67454D6DA1F7A501 /* SplitFlapConfiguration.swift in Sources */,
+				9B6F9B6E67454D6DA1F7A501 /* SplitFlapConfigureSheetController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SplitFlap/CharacterGrid.swift
+++ b/SplitFlap/CharacterGrid.swift
@@ -10,9 +10,13 @@ final class CharacterGrid {
         let cols: Int
         let originX: CGFloat
         let originY: CGFloat
+        let paletteIdentifier: String
 
         func canReusePanelFrames(from previous: LayoutMetrics) -> Bool {
-            rows == previous.rows && cols == previous.cols && panelSize == previous.panelSize
+            rows == previous.rows
+                && cols == previous.cols
+                && panelSize == previous.panelSize
+                && paletteIdentifier == previous.paletteIdentifier
         }
     }
 
@@ -27,10 +31,12 @@ final class CharacterGrid {
     private var panelSize: CGSize = .zero
     private let gap: CGFloat = 2
     private var lastLayoutMetrics: LayoutMetrics?
+    private var configuration: SplitFlapConfiguration
 
     // MARK: - Init
 
-    init(bounds: CGRect, isPreview: Bool, scale: CGFloat) {
+    init(bounds: CGRect, isPreview: Bool, scale: CGFloat, configuration: SplitFlapConfiguration) {
+        self.configuration = configuration
         layout(bounds: bounds, isPreview: isPreview, scale: scale)
     }
 
@@ -38,7 +44,7 @@ final class CharacterGrid {
 
     private func computePanelSize(for bounds: CGRect, isPreview: Bool) -> CGSize {
         let aspectRatio: CGFloat = 0.62   // width / height (real Solari: slightly taller than wide)
-        let targetRows: CGFloat = isPreview ? 5 : 15
+        let targetRows = CGFloat(configuration.rowCount(isPreview: isPreview))
 
         let totalGapH = gap * (targetRows + 1)
         let h = floor((bounds.height - totalGapH) / targetRows)
@@ -51,6 +57,7 @@ final class CharacterGrid {
         let dimensionsChanged = rows != metrics.rows
             || cols != metrics.cols
             || !hasPanelGrid(rows: metrics.rows, cols: metrics.cols)
+            || lastLayoutMetrics?.paletteIdentifier != metrics.paletteIdentifier
         let framesOnly = lastLayoutMetrics.map { metrics.canReusePanelFrames(from: $0) } ?? false
 
         panelSize = metrics.panelSize
@@ -60,7 +67,7 @@ final class CharacterGrid {
         CATransaction.begin()
         CATransaction.setDisableActions(true)
         containerLayer.frame = metrics.bounds
-        containerLayer.backgroundColor = BoardColors.screenBg
+        containerLayer.backgroundColor = configuration.theme.palette.screenBg
 
         if dimensionsChanged {
             rebuildPanels(using: metrics, scale: scale)
@@ -86,7 +93,11 @@ final class CharacterGrid {
         for r in 0..<rows {
             var row: [SplitFlapPanel] = []
             for c in 0..<cols {
-                let panel = SplitFlapPanel(size: metrics.panelSize, scale: scale)
+                let panel = SplitFlapPanel(
+                    size: metrics.panelSize,
+                    scale: scale,
+                    palette: configuration.theme.palette
+                )
                 panel.panelLayer.frame = panelFrame(row: r, col: c, metrics: metrics)
                 containerLayer.addSublayer(panel.panelLayer)
                 row.append(panel)
@@ -129,7 +140,8 @@ final class CharacterGrid {
 
     // MARK: - Resize
 
-    func rebuild(bounds: CGRect, isPreview: Bool, scale: CGFloat) {
+    func rebuild(bounds: CGRect, isPreview: Bool, scale: CGFloat, configuration: SplitFlapConfiguration) {
+        self.configuration = configuration
         layout(bounds: bounds, isPreview: isPreview, scale: scale)
     }
 
@@ -151,7 +163,8 @@ final class CharacterGrid {
             rows: rows,
             cols: cols,
             originX: originX,
-            originY: originY
+            originY: originY,
+            paletteIdentifier: configuration.theme.palette.identifier
         )
     }
 

--- a/SplitFlap/CharacterSet.swift
+++ b/SplitFlap/CharacterSet.swift
@@ -1,65 +1,87 @@
 import Foundation
 
-// Characters in the order they appear on a mechanical Solari drum.
-// Panels always advance *forward* through this sequence (never backward),
-// just like a physical split-flap display.
-enum SplitFlapCharacter: Int, CaseIterable {
-    case space = 0
-    case A, B, C, D, E, F, G, H, I, J, K, L, M
-    case N, O, P, Q, R, S, T, U, V, W, X, Y, Z
-    case zero, one, two, three, four, five, six, seven, eight, nine
-    case period, comma, hyphen, slash, colon
+// A displayable split-flap cell. Known Solari drum characters retain the
+// mechanical forward-only sequence; arbitrary Unicode grapheme clusters render
+// directly as a one-step flip target.
+struct SplitFlapCharacter: Hashable {
+    let displayString: String
 
-    var displayString: String {
-        switch self {
-        case .space:   return " "
-        case .A: return "A"; case .B: return "B"; case .C: return "C"
-        case .D: return "D"; case .E: return "E"; case .F: return "F"
-        case .G: return "G"; case .H: return "H"; case .I: return "I"
-        case .J: return "J"; case .K: return "K"; case .L: return "L"
-        case .M: return "M"; case .N: return "N"; case .O: return "O"
-        case .P: return "P"; case .Q: return "Q"; case .R: return "R"
-        case .S: return "S"; case .T: return "T"; case .U: return "U"
-        case .V: return "V"; case .W: return "W"; case .X: return "X"
-        case .Y: return "Y"; case .Z: return "Z"
-        case .zero:  return "0"; case .one:   return "1"; case .two:   return "2"
-        case .three: return "3"; case .four:  return "4"; case .five:  return "5"
-        case .six:   return "6"; case .seven: return "7"; case .eight: return "8"
-        case .nine:  return "9"
-        case .period: return "."; case .comma:  return ","
-        case .hyphen: return "-"; case .slash:  return "/"
-        case .colon:  return ":"
-        }
+    init(_ displayString: String) {
+        self.displayString = displayString.isEmpty ? " " : displayString
     }
 
-    static let count: Int = SplitFlapCharacter.allCases.count
-    private static let lookupByDisplayString: [String: SplitFlapCharacter] = {
-        Dictionary(uniqueKeysWithValues: allCases.map { ($0.displayString, $0) })
-    }()
+    static let space = SplitFlapCharacter(" ")
+
+    static let drumCharacters: [SplitFlapCharacter] = [
+        " ",
+        "A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M",
+        "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z",
+        "0", "1", "2", "3", "4", "5", "6", "7", "8", "9",
+        ".", ",", "-", "/", ":"
+    ].map(SplitFlapCharacter.init)
+
+    static let count: Int = drumCharacters.count
+
+    private static let lookupByDisplayString = Dictionary(
+        uniqueKeysWithValues: drumCharacters.map { ($0.displayString, $0) }
+    )
+
+    private static let drumIndexByDisplayString = Dictionary(
+        uniqueKeysWithValues: drumCharacters.enumerated().map { ($0.element.displayString, $0.offset) }
+    )
+
+    private var drumIndex: Int? {
+        Self.drumIndexByDisplayString[displayString]
+    }
 
     // Advance one step forward from this character.
     var next: SplitFlapCharacter {
-        let nextRaw = (rawValue + 1) % SplitFlapCharacter.count
-        return SplitFlapCharacter(rawValue: nextRaw)!
+        guard let drumIndex else { return self }
+        let nextIndex = (drumIndex + 1) % Self.drumCharacters.count
+        return Self.drumCharacters[nextIndex]
     }
 
     // Number of forward steps needed to reach `target` from `self`.
     func stepsTo(_ target: SplitFlapCharacter) -> Int {
-        if target.rawValue >= rawValue {
-            return target.rawValue - rawValue
+        guard let sourceIndex = drumIndex, let targetIndex = target.drumIndex else {
+            return self == target ? 0 : 1
         }
-        return SplitFlapCharacter.count - rawValue + target.rawValue
+
+        if targetIndex >= sourceIndex {
+            return targetIndex - sourceIndex
+        }
+        return Self.drumCharacters.count - sourceIndex + targetIndex
     }
 
-    // Return a random character (excluding space for more visual interest).
+    func sequence(to target: SplitFlapCharacter) -> [SplitFlapCharacter] {
+        guard let sourceIndex = drumIndex, target.drumIndex != nil else {
+            return self == target ? [self] : [self, target]
+        }
+
+        let steps = stepsTo(target)
+        var sequence: [SplitFlapCharacter] = [self]
+        sequence.reserveCapacity(steps + 1)
+        for offset in 1...steps {
+            sequence.append(Self.drumCharacters[(sourceIndex + offset) % Self.drumCharacters.count])
+        }
+        return sequence
+    }
+
+    // Return a random character from the physical drum alphabet.
     static func random() -> SplitFlapCharacter {
-        let all = SplitFlapCharacter.allCases
-        return all[Int.random(in: 0..<all.count)]
+        drumCharacters[Int.random(in: 0..<drumCharacters.count)]
     }
 
-    // Parse a single character string into a SplitFlapCharacter, or return .space.
+    // Parse one extended grapheme cluster. Known ASCII drum characters normalize
+    // to uppercase; all other Unicode clusters are preserved for rendering.
     static func from(_ string: String) -> SplitFlapCharacter {
-        let ch = string.uppercased()
-        return lookupByDisplayString[ch] ?? .space
+        guard let first = string.first else { return .space }
+        let grapheme = String(first)
+        let normalized = grapheme.uppercased()
+        return lookupByDisplayString[normalized] ?? SplitFlapCharacter(grapheme)
+    }
+
+    static func characters(in text: String) -> [SplitFlapCharacter] {
+        text.map { from(String($0)) }
     }
 }

--- a/SplitFlap/DisplayClock.swift
+++ b/SplitFlap/DisplayClock.swift
@@ -100,6 +100,9 @@ final class DisplayClock: NSObject {
 
     private weak var grid: CharacterGrid?
     private let animator = FlipAnimator()
+    private let contentProvider: SplitFlapContentProvider
+    private var configuration: SplitFlapConfiguration
+    private let isPreview: Bool
 
     private var ticker: DisplayTicker?
     private var lastIdleTickTimestamp: CFTimeInterval?
@@ -114,22 +117,23 @@ final class DisplayClock: NSObject {
 
     // Tick interval for the idle phase (seconds between random panel checks)
     private let idleTickInterval: TimeInterval = 0.15
-    // How many ticks before switching to a wave phase
-    private let idleTickDuration: Int = 30
-    // How many ticks the wave phase lasts
-    private let waveTickDuration: Int = 80
-
-    // Fraction of panels that flip on each idle tick
-    private let idleDensity: Double = 0.04
     private let maxIdleFlipStartsPerTick: Int = 12
     private let maxActiveIdleFlips: Int = 48
     private var runGeneration: Int = 0
 
     // MARK: - Init
 
-    init(grid: CharacterGrid) {
+    init(grid: CharacterGrid, configuration: SplitFlapConfiguration, isPreview: Bool) {
         self.grid = grid
+        self.configuration = configuration
+        self.contentProvider = SplitFlapContentProvider(configuration: configuration)
+        self.isPreview = isPreview
         super.init()
+    }
+
+    func update(configuration: SplitFlapConfiguration) {
+        self.configuration = configuration
+        contentProvider.update(configuration: configuration)
     }
 
     // MARK: - Lifecycle
@@ -145,6 +149,12 @@ final class DisplayClock: NSObject {
         ticker = makeTicker(screen: screen)
         if ticker == nil {
             isRunning = false
+        }
+
+        if isPreview, let grid {
+            applyTargets(contentProvider.nextTargets(rows: grid.rows, cols: grid.cols, preview: true), grid: grid)
+        } else if configuration.displayMode != .random, let grid {
+            startWave(grid: grid)
         }
     }
 
@@ -195,7 +205,9 @@ final class DisplayClock: NSObject {
 
         switch phase {
         case .idle:
-            idleTick(grid: grid)
+            if configuration.idleShuffleEnabled {
+                idleTick(grid: grid)
+            }
             if phaseTickCount >= idleTickDuration {
                 phase = .wave
                 phaseTickCount = 0
@@ -221,8 +233,9 @@ final class DisplayClock: NSObject {
         let activeCount = all.reduce(0) { $0 + ($1.isFlipping ? 1 : 0) }
         let activeBudget = maxActiveIdleFlips - activeCount
         guard activeBudget > 0 else { return }
+        guard configuration.idleDensity > 0 else { return }
 
-        let requestedCount = max(1, Int(Double(all.count) * idleDensity))
+        let requestedCount = max(1, Int(Double(all.count) * configuration.idleDensity))
         let flipCount = min(requestedCount, maxIdleFlipStartsPerTick, activeBudget, all.count)
         let generation = runGeneration
 
@@ -259,8 +272,7 @@ final class DisplayClock: NSObject {
     // MARK: - Wave phase
 
     private func startWave(grid: CharacterGrid) {
-        // Choose a random target character for each panel (or fill with a message).
-        let targets = buildWaveTargets(grid: grid)
+        let targets = contentProvider.nextTargets(rows: grid.rows, cols: grid.cols)
         let generation = runGeneration
 
         // Stagger column-by-column by assigning Core Animation begin times in one pass.
@@ -293,16 +305,20 @@ final class DisplayClock: NSObject {
         }
     }
 
-    private func buildWaveTargets(grid: CharacterGrid) -> [[SplitFlapCharacter]] {
-        var targets: [[SplitFlapCharacter]] = []
-        for _ in 0..<grid.rows {
-            var row: [SplitFlapCharacter] = []
-            for _ in 0..<grid.cols {
-                row.append(SplitFlapCharacter.random())
+    private var idleTickDuration: Int {
+        max(1, Int(configuration.waveIntervalSeconds / idleTickInterval))
+    }
+
+    private var waveTickDuration: Int {
+        max(20, idleTickDuration / 2)
+    }
+
+    private func applyTargets(_ targets: [[SplitFlapCharacter]], grid: CharacterGrid) {
+        for row in 0..<min(grid.rows, targets.count) {
+            for col in 0..<min(grid.cols, targets[row].count) {
+                grid.panel(row: row, col: col)?.setCharacter(targets[row][col], animated: false)
             }
-            targets.append(row)
         }
-        return targets
     }
 
     private func isCurrentGeneration(_ generation: Int) -> Bool {

--- a/SplitFlap/DisplayClock.swift
+++ b/SplitFlap/DisplayClock.swift
@@ -153,7 +153,7 @@ final class DisplayClock: NSObject {
 
         if isPreview, let grid {
             applyTargets(contentProvider.nextTargets(rows: grid.rows, cols: grid.cols, preview: true), grid: grid)
-        } else if configuration.displayMode != .random, let grid {
+        } else if shouldSeedInitialWave, let grid {
             startWave(grid: grid)
         }
     }
@@ -305,8 +305,12 @@ final class DisplayClock: NSObject {
         }
     }
 
+    private var shouldSeedInitialWave: Bool {
+        configuration.displayMode != .random || !configuration.idleShuffleEnabled
+    }
+
     private var idleTickDuration: Int {
-        max(1, Int(configuration.waveIntervalSeconds / idleTickInterval))
+        max(1, Int(configuration.waveIntervalSeconds / idleTickInterval) - waveTickDuration)
     }
 
     private var waveTickDuration: Int {

--- a/SplitFlap/SplitFlapConfiguration.swift
+++ b/SplitFlap/SplitFlapConfiguration.swift
@@ -1,0 +1,269 @@
+import AppKit
+import Foundation
+import ScreenSaver
+
+enum SplitFlapDisplayMode: String, CaseIterable {
+    case random
+    case messages
+    case clock
+    case date
+
+    var title: String {
+        switch self {
+        case .random: return "Random"
+        case .messages: return "Messages"
+        case .clock: return "Clock"
+        case .date: return "Date"
+        }
+    }
+}
+
+enum SplitFlapMessageOrder: String, CaseIterable {
+    case sequential
+    case random
+
+    var title: String {
+        switch self {
+        case .sequential: return "Sequential"
+        case .random: return "Random"
+        }
+    }
+}
+
+struct SplitFlapPalette {
+    let identifier: String
+    let panelBackground: CGColor
+    let character: CGColor
+    let divider: CGColor
+    let screenBg: CGColor
+}
+
+enum SplitFlapTheme: String, CaseIterable {
+    case classic
+    case terminal
+    case monochrome
+
+    var title: String {
+        switch self {
+        case .classic: return "Classic Amber"
+        case .terminal: return "Terminal Green"
+        case .monochrome: return "Monochrome"
+        }
+    }
+
+    var palette: SplitFlapPalette {
+        switch self {
+        case .classic:
+            return SplitFlapPalette(
+                identifier: rawValue,
+                panelBackground: CGColor(red: 0.06, green: 0.06, blue: 0.07, alpha: 1.0),
+                character: CGColor(red: 0.98, green: 0.82, blue: 0.25, alpha: 1.0),
+                divider: CGColor(red: 0.01, green: 0.01, blue: 0.02, alpha: 1.0),
+                screenBg: CGColor(red: 0.04, green: 0.04, blue: 0.05, alpha: 1.0)
+            )
+        case .terminal:
+            return SplitFlapPalette(
+                identifier: rawValue,
+                panelBackground: CGColor(red: 0.02, green: 0.05, blue: 0.04, alpha: 1.0),
+                character: CGColor(red: 0.35, green: 1.0, blue: 0.58, alpha: 1.0),
+                divider: CGColor(red: 0.0, green: 0.02, blue: 0.015, alpha: 1.0),
+                screenBg: CGColor(red: 0.01, green: 0.025, blue: 0.02, alpha: 1.0)
+            )
+        case .monochrome:
+            return SplitFlapPalette(
+                identifier: rawValue,
+                panelBackground: CGColor(red: 0.08, green: 0.08, blue: 0.085, alpha: 1.0),
+                character: CGColor(red: 0.94, green: 0.94, blue: 0.9, alpha: 1.0),
+                divider: CGColor(red: 0.015, green: 0.015, blue: 0.018, alpha: 1.0),
+                screenBg: CGColor(red: 0.035, green: 0.035, blue: 0.04, alpha: 1.0)
+            )
+        }
+    }
+}
+
+struct SplitFlapConfiguration {
+    var displayMode: SplitFlapDisplayMode = .messages
+    var messageText: String = "SplitFlap\nUnicode OK\nHello World"
+    var messageOrder: SplitFlapMessageOrder = .sequential
+    var waveIntervalSeconds: TimeInterval = 8
+    var idleShuffleEnabled: Bool = true
+    var idleDensity: Double = 0.04
+    var targetRows: Int = 9
+    var theme: SplitFlapTheme = .classic
+
+    var messages: [String] {
+        let lines = messageText
+            .split(whereSeparator: \.isNewline)
+            .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        return lines.isEmpty ? ["SplitFlap"] : lines
+    }
+
+    func rowCount(isPreview: Bool) -> Int {
+        if isPreview {
+            return min(max(3, targetRows), 5)
+        }
+        return min(max(4, targetRows), 24)
+    }
+}
+
+enum SplitFlapConfigurationStore {
+    private static let moduleName = "com.omt.SplitFlap"
+
+    private enum Key {
+        static let displayMode = "displayMode"
+        static let messageText = "messageText"
+        static let messageOrder = "messageOrder"
+        static let waveIntervalSeconds = "waveIntervalSeconds"
+        static let idleShuffleEnabled = "idleShuffleEnabled"
+        static let idleDensity = "idleDensity"
+        static let targetRows = "targetRows"
+        static let theme = "theme"
+    }
+
+    private static var defaults: UserDefaults {
+        ScreenSaverDefaults(forModuleWithName: moduleName) ?? .standard
+    }
+
+    static func load() -> SplitFlapConfiguration {
+        let fallback = SplitFlapConfiguration()
+        let defaults = defaults
+        defaults.register(defaults: [
+            Key.displayMode: fallback.displayMode.rawValue,
+            Key.messageText: fallback.messageText,
+            Key.messageOrder: fallback.messageOrder.rawValue,
+            Key.waveIntervalSeconds: fallback.waveIntervalSeconds,
+            Key.idleShuffleEnabled: fallback.idleShuffleEnabled,
+            Key.idleDensity: fallback.idleDensity,
+            Key.targetRows: fallback.targetRows,
+            Key.theme: fallback.theme.rawValue
+        ])
+
+        return SplitFlapConfiguration(
+            displayMode: SplitFlapDisplayMode(rawValue: defaults.string(forKey: Key.displayMode) ?? "") ?? fallback.displayMode,
+            messageText: defaults.string(forKey: Key.messageText) ?? fallback.messageText,
+            messageOrder: SplitFlapMessageOrder(rawValue: defaults.string(forKey: Key.messageOrder) ?? "") ?? fallback.messageOrder,
+            waveIntervalSeconds: bounded(defaults.double(forKey: Key.waveIntervalSeconds), min: 2, max: 60, fallback: fallback.waveIntervalSeconds),
+            idleShuffleEnabled: defaults.object(forKey: Key.idleShuffleEnabled) as? Bool ?? fallback.idleShuffleEnabled,
+            idleDensity: bounded(defaults.double(forKey: Key.idleDensity), min: 0, max: 0.2, fallback: fallback.idleDensity),
+            targetRows: min(max(defaults.integer(forKey: Key.targetRows), 4), 24),
+            theme: SplitFlapTheme(rawValue: defaults.string(forKey: Key.theme) ?? "") ?? fallback.theme
+        )
+    }
+
+    static func save(_ configuration: SplitFlapConfiguration) {
+        let defaults = defaults
+        defaults.set(configuration.displayMode.rawValue, forKey: Key.displayMode)
+        defaults.set(configuration.messageText, forKey: Key.messageText)
+        defaults.set(configuration.messageOrder.rawValue, forKey: Key.messageOrder)
+        defaults.set(configuration.waveIntervalSeconds, forKey: Key.waveIntervalSeconds)
+        defaults.set(configuration.idleShuffleEnabled, forKey: Key.idleShuffleEnabled)
+        defaults.set(configuration.idleDensity, forKey: Key.idleDensity)
+        defaults.set(configuration.targetRows, forKey: Key.targetRows)
+        defaults.set(configuration.theme.rawValue, forKey: Key.theme)
+        defaults.synchronize()
+    }
+
+    private static func bounded(_ value: Double, min: Double, max: Double, fallback: Double) -> Double {
+        guard value.isFinite, value >= min, value <= max else { return fallback }
+        return value
+    }
+}
+
+final class SplitFlapContentProvider {
+    private var configuration: SplitFlapConfiguration
+    private var messageIndex = 0
+
+    init(configuration: SplitFlapConfiguration) {
+        self.configuration = configuration
+    }
+
+    func update(configuration: SplitFlapConfiguration) {
+        self.configuration = configuration
+        messageIndex = min(messageIndex, max(configuration.messages.count - 1, 0))
+    }
+
+    func nextTargets(rows: Int, cols: Int, preview: Bool = false) -> [[SplitFlapCharacter]] {
+        switch configuration.displayMode {
+        case .random:
+            if preview {
+                return textTargets(["SplitFlap"], rows: rows, cols: cols)
+            }
+            return randomTargets(rows: rows, cols: cols)
+        case .messages:
+            return textTargets([nextMessage()], rows: rows, cols: cols)
+        case .clock:
+            return textTargets([Self.clockFormatter.string(from: Date())], rows: rows, cols: cols)
+        case .date:
+            return textTargets([Self.dateFormatter.string(from: Date())], rows: rows, cols: cols)
+        }
+    }
+
+    private func nextMessage() -> String {
+        let messages = configuration.messages
+        switch configuration.messageOrder {
+        case .sequential:
+            let message = messages[messageIndex % messages.count]
+            messageIndex = (messageIndex + 1) % messages.count
+            return message
+        case .random:
+            return messages.randomElement() ?? "SplitFlap"
+        }
+    }
+
+    private func randomTargets(rows: Int, cols: Int) -> [[SplitFlapCharacter]] {
+        (0..<rows).map { _ in
+            (0..<cols).map { _ in SplitFlapCharacter.random() }
+        }
+    }
+
+    private func textTargets(_ textLines: [String], rows: Int, cols: Int) -> [[SplitFlapCharacter]] {
+        var targets = Array(
+            repeating: Array(repeating: SplitFlapCharacter.space, count: cols),
+            count: rows
+        )
+        guard rows > 0, cols > 0 else { return targets }
+
+        let wrapped = textLines.flatMap { wrappedLines($0, maxWidth: cols) }
+        let visibleLines = Array(wrapped.prefix(rows))
+        let startRow = max(0, (rows - visibleLines.count) / 2)
+
+        for (offset, line) in visibleLines.enumerated() {
+            let characters = Array(line.prefix(cols))
+            let startCol = max(0, (cols - characters.count) / 2)
+            for (index, character) in characters.enumerated() {
+                targets[startRow + offset][startCol + index] = character
+            }
+        }
+
+        return targets
+    }
+
+    private func wrappedLines(_ text: String, maxWidth: Int) -> [[SplitFlapCharacter]] {
+        let characters = SplitFlapCharacter.characters(in: text)
+        guard !characters.isEmpty else { return [[.space]] }
+        guard maxWidth > 0 else { return [] }
+
+        var lines: [[SplitFlapCharacter]] = []
+        var index = 0
+        while index < characters.count {
+            let end = min(index + maxWidth, characters.count)
+            lines.append(Array(characters[index..<end]))
+            index = end
+        }
+        return lines
+    }
+
+    private static let clockFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm:ss"
+        return formatter
+    }()
+
+    private static let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .none
+        return formatter
+    }()
+}

--- a/SplitFlap/SplitFlapConfigureSheetController.swift
+++ b/SplitFlap/SplitFlapConfigureSheetController.swift
@@ -1,0 +1,193 @@
+import AppKit
+
+final class SplitFlapConfigureSheetController: NSObject {
+    private var configuration: SplitFlapConfiguration
+    private let onSave: (SplitFlapConfiguration) -> Void
+
+    let window: NSWindow
+
+    private let modePopup = NSPopUpButton()
+    private let messageTextView = NSTextView()
+    private let orderPopup = NSPopUpButton()
+    private let waveSlider = NSSlider(value: 8, minValue: 2, maxValue: 60, target: nil, action: nil)
+    private let waveValueLabel = NSTextField(labelWithString: "")
+    private let idleShuffleButton = NSButton(checkboxWithTitle: "Shuffle idle panels between waves", target: nil, action: nil)
+    private let idleDensitySlider = NSSlider(value: 0.04, minValue: 0, maxValue: 0.2, target: nil, action: nil)
+    private let idleDensityValueLabel = NSTextField(labelWithString: "")
+    private let rowsSlider = NSSlider(value: 9, minValue: 4, maxValue: 24, target: nil, action: nil)
+    private let rowsValueLabel = NSTextField(labelWithString: "")
+    private let themePopup = NSPopUpButton()
+
+    init(configuration: SplitFlapConfiguration, onSave: @escaping (SplitFlapConfiguration) -> Void) {
+        self.configuration = configuration
+        self.onSave = onSave
+        self.window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 560, height: 520),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        super.init()
+        buildWindow()
+        loadConfiguration()
+    }
+
+    private func buildWindow() {
+        window.title = "SplitFlap Options"
+        window.isReleasedWhenClosed = false
+
+        let contentView = NSView()
+        contentView.translatesAutoresizingMaskIntoConstraints = false
+        window.contentView = contentView
+
+        let stack = NSStackView()
+        stack.orientation = .vertical
+        stack.alignment = .leading
+        stack.spacing = 14
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        contentView.addSubview(stack)
+
+        modePopup.addItems(withTitles: SplitFlapDisplayMode.allCases.map(\.title))
+        orderPopup.addItems(withTitles: SplitFlapMessageOrder.allCases.map(\.title))
+        themePopup.addItems(withTitles: SplitFlapTheme.allCases.map(\.title))
+
+        messageTextView.minSize = NSSize(width: 0, height: 120)
+        messageTextView.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
+        messageTextView.isVerticallyResizable = true
+        messageTextView.isHorizontallyResizable = false
+        messageTextView.autoresizingMask = [.width]
+        messageTextView.textContainer?.containerSize = NSSize(width: 500, height: CGFloat.greatestFiniteMagnitude)
+        messageTextView.textContainer?.widthTracksTextView = true
+        messageTextView.font = .systemFont(ofSize: 13)
+
+        let scrollView = NSScrollView()
+        scrollView.borderType = .bezelBorder
+        scrollView.hasVerticalScroller = true
+        scrollView.documentView = messageTextView
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.heightAnchor.constraint(equalToConstant: 130).isActive = true
+        scrollView.widthAnchor.constraint(equalToConstant: 500).isActive = true
+
+        [waveSlider, idleDensitySlider, rowsSlider].forEach {
+            $0.translatesAutoresizingMaskIntoConstraints = false
+            $0.target = self
+            $0.action = #selector(sliderChanged(_:))
+            $0.widthAnchor.constraint(equalToConstant: 300).isActive = true
+        }
+
+        stack.addArrangedSubview(row(label: "Display", control: modePopup))
+        stack.addArrangedSubview(labeledBlock(label: "Messages", control: scrollView))
+        stack.addArrangedSubview(row(label: "Message order", control: orderPopup))
+        stack.addArrangedSubview(sliderRow(label: "Wave interval", slider: waveSlider, valueLabel: waveValueLabel))
+        stack.addArrangedSubview(idleShuffleButton)
+        stack.addArrangedSubview(sliderRow(label: "Idle density", slider: idleDensitySlider, valueLabel: idleDensityValueLabel))
+        stack.addArrangedSubview(sliderRow(label: "Board rows", slider: rowsSlider, valueLabel: rowsValueLabel))
+        stack.addArrangedSubview(row(label: "Theme", control: themePopup))
+
+        let buttons = NSStackView()
+        buttons.orientation = .horizontal
+        buttons.alignment = .centerY
+        buttons.spacing = 10
+        buttons.translatesAutoresizingMaskIntoConstraints = false
+
+        let spacer = NSView()
+        spacer.translatesAutoresizingMaskIntoConstraints = false
+        let cancel = NSButton(title: "Cancel", target: self, action: #selector(cancel(_:)))
+        let save = NSButton(title: "Save", target: self, action: #selector(save(_:)))
+        save.keyEquivalent = "\r"
+        buttons.addArrangedSubview(spacer)
+        buttons.addArrangedSubview(cancel)
+        buttons.addArrangedSubview(save)
+        spacer.widthAnchor.constraint(greaterThanOrEqualToConstant: 280).isActive = true
+        stack.addArrangedSubview(buttons)
+
+        NSLayoutConstraint.activate([
+            stack.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 24),
+            stack.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -24),
+            stack.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 24),
+            stack.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -18)
+        ])
+    }
+
+    private func loadConfiguration() {
+        modePopup.selectItem(at: SplitFlapDisplayMode.allCases.firstIndex(of: configuration.displayMode) ?? 0)
+        messageTextView.string = configuration.messageText
+        orderPopup.selectItem(at: SplitFlapMessageOrder.allCases.firstIndex(of: configuration.messageOrder) ?? 0)
+        waveSlider.doubleValue = configuration.waveIntervalSeconds
+        idleShuffleButton.state = configuration.idleShuffleEnabled ? .on : .off
+        idleDensitySlider.doubleValue = configuration.idleDensity
+        rowsSlider.integerValue = configuration.targetRows
+        themePopup.selectItem(at: SplitFlapTheme.allCases.firstIndex(of: configuration.theme) ?? 0)
+        updateValueLabels()
+    }
+
+    private func row(label: String, control: NSView) -> NSView {
+        let labelView = NSTextField(labelWithString: label)
+        labelView.translatesAutoresizingMaskIntoConstraints = false
+        labelView.widthAnchor.constraint(equalToConstant: 120).isActive = true
+
+        let row = NSStackView(views: [labelView, control])
+        row.orientation = .horizontal
+        row.alignment = .centerY
+        row.spacing = 14
+        return row
+    }
+
+    private func sliderRow(label: String, slider: NSSlider, valueLabel: NSTextField) -> NSView {
+        valueLabel.alignment = .right
+        valueLabel.translatesAutoresizingMaskIntoConstraints = false
+        valueLabel.widthAnchor.constraint(equalToConstant: 70).isActive = true
+        return row(label: label, control: NSStackView(views: [slider, valueLabel]))
+    }
+
+    private func labeledBlock(label: String, control: NSView) -> NSView {
+        let labelView = NSTextField(labelWithString: label)
+        let block = NSStackView(views: [labelView, control])
+        block.orientation = .vertical
+        block.alignment = .leading
+        block.spacing = 6
+        return block
+    }
+
+    @objc private func sliderChanged(_ sender: NSSlider) {
+        updateValueLabels()
+    }
+
+    private func updateValueLabels() {
+        waveValueLabel.stringValue = "\(Int(waveSlider.doubleValue.rounded())) sec"
+        idleDensityValueLabel.stringValue = "\(Int((idleDensitySlider.doubleValue * 100).rounded()))%"
+        rowsValueLabel.stringValue = "\(rowsSlider.integerValue)"
+    }
+
+    @objc private func save(_ sender: Any?) {
+        configuration.displayMode = SplitFlapDisplayMode.allCases[safe: modePopup.indexOfSelectedItem] ?? .messages
+        configuration.messageText = messageTextView.string
+        configuration.messageOrder = SplitFlapMessageOrder.allCases[safe: orderPopup.indexOfSelectedItem] ?? .sequential
+        configuration.waveIntervalSeconds = waveSlider.doubleValue.rounded()
+        configuration.idleShuffleEnabled = idleShuffleButton.state == .on
+        configuration.idleDensity = idleDensitySlider.doubleValue
+        configuration.targetRows = rowsSlider.integerValue
+        configuration.theme = SplitFlapTheme.allCases[safe: themePopup.indexOfSelectedItem] ?? .classic
+
+        onSave(configuration)
+        closeSheet()
+    }
+
+    @objc private func cancel(_ sender: Any?) {
+        closeSheet()
+    }
+
+    private func closeSheet() {
+        if let sheetParent = window.sheetParent {
+            sheetParent.endSheet(window)
+        }
+        window.close()
+    }
+}
+
+private extension Array {
+    subscript(safe index: Int) -> Element? {
+        guard indices.contains(index) else { return nil }
+        return self[index]
+    }
+}

--- a/SplitFlap/SplitFlapPanel.swift
+++ b/SplitFlap/SplitFlapPanel.swift
@@ -4,14 +4,6 @@ import IOSurface
 import CoreVideo
 import Darwin
 
-// Colors matching a classic Solari board.
-enum BoardColors {
-    static let panelBackground = CGColor(red: 0.06, green: 0.06, blue: 0.07, alpha: 1.0)
-    static let character       = CGColor(red: 0.98, green: 0.82, blue: 0.25, alpha: 1.0)
-    static let divider         = CGColor(red: 0.01, green: 0.01, blue: 0.02, alpha: 1.0)
-    static let screenBg        = CGColor(red: 0.04, green: 0.04, blue: 0.05, alpha: 1.0)
-}
-
 private final class GlyphImageCache {
     static let shared = GlyphImageCache()
 
@@ -22,13 +14,14 @@ private final class GlyphImageCache {
         init(surface: IOSurface) { self.surface = surface }
     }
 
-    private let cache = NSCache<NSNumber, GlyphSurface>()
+    private let cache = NSCache<NSString, GlyphSurface>()
 
     func contents(
         for character: SplitFlapCharacter,
         panelSize: CGSize,
         scale: CGFloat,
-        half: Half
+        half: Half,
+        palette: SplitFlapPalette
     ) -> Any? {
         let panelW = panelSize.width
         let panelH = panelSize.height
@@ -36,14 +29,7 @@ private final class GlyphImageCache {
 
         let pixelWidth = max(1, Int((panelW * scale).rounded(.up)))
         let pixelHalfHeight = max(1, Int((halfH * scale).rounded(.up)))
-        // Pack the cache identity into a single integer so the hot glyph lookup
-        // (called for every keyframe of every flip) allocates nothing — no
-        // per-call interpolated string. Field widths comfortably fit even an
-        // 8K display: half-height/width stay well under 2^14 pixels.
-        let halfBit = (half == .top) ? 0 : 1
-        let key = NSNumber(
-            value: (pixelWidth << 21) | (pixelHalfHeight << 7) | (character.rawValue << 1) | halfBit
-        )
+        let key = "\(pixelWidth)x\(pixelHalfHeight):\(half.rawValue):\(palette.identifier):\(character.displayString)" as NSString
 
         if let cached = cache.object(forKey: key) {
             return cached.surface
@@ -93,24 +79,26 @@ private final class GlyphImageCache {
             context.translateBy(x: 0, y: -halfH)
         }
 
-        let fontSize = panelH * 0.72
-        let font = NSFont(name: "SFMono-Regular", size: fontSize)
-            ?? NSFont.monospacedSystemFont(ofSize: fontSize, weight: .regular)
         let paragraph = NSMutableParagraphStyle()
         paragraph.alignment = .center
 
-        let color = NSColor(cgColor: BoardColors.character) ?? .systemYellow
-        let attributes: [NSAttributedString.Key: Any] = [
-            .font: font,
-            .foregroundColor: color,
-            .paragraphStyle: paragraph
-        ]
+        let string = character.displayString as NSString
+        let color = NSColor(cgColor: palette.character) ?? .systemYellow
+        let maxTextWidth = panelW * 0.92
+        let maxTextHeight = panelH * 0.86
+        var fontSize = max(8, panelH * 0.72)
+        var attributes = textAttributes(fontSize: fontSize, color: color, paragraph: paragraph)
+        var textSize = string.size(withAttributes: attributes)
+
+        while fontSize > 7 && (textSize.width > maxTextWidth || textSize.height > maxTextHeight) {
+            fontSize -= 1
+            attributes = textAttributes(fontSize: fontSize, color: color, paragraph: paragraph)
+            textSize = string.size(withAttributes: attributes)
+        }
 
         NSGraphicsContext.saveGraphicsState()
         NSGraphicsContext.current = NSGraphicsContext(cgContext: context, flipped: false)
 
-        let string = character.displayString as NSString
-        let textSize = string.size(withAttributes: attributes)
         let drawRect = CGRect(
             x: 0,
             y: floor((panelH - textSize.height) / 2),
@@ -123,6 +111,19 @@ private final class GlyphImageCache {
         let glyphSurface = GlyphSurface(surface: surface)
         cache.setObject(glyphSurface, forKey: key)
         return surface
+    }
+
+    private func textAttributes(
+        fontSize: CGFloat,
+        color: NSColor,
+        paragraph: NSParagraphStyle
+    ) -> [NSAttributedString.Key: Any] {
+        let font = NSFont.monospacedSystemFont(ofSize: fontSize, weight: .regular)
+        return [
+            .font: font,
+            .foregroundColor: color,
+            .paragraphStyle: paragraph
+        ]
     }
 }
 
@@ -184,14 +185,16 @@ final class SplitFlapPanel {
     private var h: CGFloat = 0
     private var mid: CGFloat = 0
     private var contentsScale: CGFloat = 1
+    private let palette: SplitFlapPalette
 
     // MARK: - Setup
 
-    init(size: CGSize, scale: CGFloat) {
+    init(size: CGSize, scale: CGFloat, palette: SplitFlapPalette) {
         w = size.width
         h = size.height
         mid = size.height / 2
         contentsScale = scale
+        self.palette = palette
         buildLayerTree()
         setCharacter(.space, animated: false)
     }
@@ -199,7 +202,7 @@ final class SplitFlapPanel {
     private func buildLayerTree() {
         panelLayer.bounds = CGRect(x: 0, y: 0, width: w, height: h)
         panelLayer.anchorPoint = CGPoint(x: 0, y: 0)
-        panelLayer.backgroundColor = BoardColors.panelBackground
+        panelLayer.backgroundColor = palette.panelBackground
         panelLayer.cornerRadius = 1
         panelLayer.masksToBounds = true
 
@@ -216,7 +219,7 @@ final class SplitFlapPanel {
         bottomFlapContainer.isDoubleSided = false
 
         dividerLayer.frame = CGRect(x: 0, y: mid - 0.5, width: w, height: 1)
-        dividerLayer.backgroundColor = BoardColors.divider
+        dividerLayer.backgroundColor = palette.divider
 
         panelLayer.addSublayer(staticBottomLayer)
         panelLayer.addSublayer(staticTopLayer)
@@ -331,14 +334,9 @@ final class SplitFlapPanel {
         guard steps > 0 else { completion?(); return }
         guard !isFlipping else { completion?(); return }
 
-        // Drum sequence: seq[0] == current, seq[steps] == target.
-        var seq: [SplitFlapCharacter] = [currentCharacter]
-        seq.reserveCapacity(steps + 1)
-        var ch = currentCharacter
-        for _ in 0..<steps {
-            ch = ch.next
-            seq.append(ch)
-        }
+        // Drum characters keep their mechanical forward sequence. Arbitrary
+        // Unicode graphemes are valid targets and resolve as a direct flip.
+        let seq = currentCharacter.sequence(to: target)
 
         // Pre-resolve every glyph half the sequence will show. If any surface
         // is unavailable, fall back to a plain snap so the board still reaches
@@ -468,7 +466,8 @@ final class SplitFlapPanel {
             for: character,
             panelSize: CGSize(width: w, height: h),
             scale: contentsScale,
-            half: half
+            half: half,
+            palette: palette
         )
     }
 
@@ -513,7 +512,8 @@ final class SplitFlapPanel {
             for: character,
             panelSize: CGSize(width: w, height: h),
             scale: layer.contentsScale,
-            half: half
+            half: half,
+            palette: palette
         )
     }
 

--- a/SplitFlap/SplitFlapView.swift
+++ b/SplitFlap/SplitFlapView.swift
@@ -13,6 +13,9 @@ final class SplitFlapView: ScreenSaverView {
     private var observedWindow: NSWindow?
     private var windowObservers: [NSObjectProtocol] = []
     private var isClockRunning = false
+    private var isPreviewInstance = false
+    private var configuration = SplitFlapConfigurationStore.load()
+    private var configureSheetController: SplitFlapConfigureSheetController?
 
     // MARK: - Init
 
@@ -27,21 +30,29 @@ final class SplitFlapView: ScreenSaverView {
     }
 
     private func setup(isPreview: Bool) {
+        isPreviewInstance = isPreview
+        configuration = SplitFlapConfigurationStore.load()
+
         // CALayer-backed view is required for all CAAnimation to work.
         wantsLayer = true
 
         rootLayer = CALayer()
         rootLayer.frame = bounds
-        rootLayer.backgroundColor = BoardColors.screenBg
+        rootLayer.backgroundColor = configuration.theme.palette.screenBg
         layer = rootLayer
 
         let scale = NSScreen.main?.backingScaleFactor ?? 2.0
 
-        let g = CharacterGrid(bounds: bounds, isPreview: isPreview, scale: scale)
+        let g = CharacterGrid(
+            bounds: bounds,
+            isPreview: isPreview,
+            scale: scale,
+            configuration: configuration
+        )
         rootLayer.addSublayer(g.containerLayer)
         grid = g
 
-        clock = DisplayClock(grid: g)
+        clock = DisplayClock(grid: g, configuration: configuration, isPreview: isPreview)
 
         // Do NOT use animateOneFrame() timer — all animation is CAAnimation-driven.
         animationTimeInterval = 60.0  // keep ScreenSaverView's empty framework timer cold
@@ -76,10 +87,14 @@ final class SplitFlapView: ScreenSaverView {
 
     override func resize(withOldSuperviewSize oldSize: NSSize) {
         super.resize(withOldSuperviewSize: oldSize)
-        let isPreview = self.bounds.width < 400
         let scale = NSScreen.main?.backingScaleFactor ?? 2.0
         rootLayer.frame = bounds
-        grid?.rebuild(bounds: bounds, isPreview: isPreview, scale: scale)
+        grid?.rebuild(
+            bounds: bounds,
+            isPreview: isPreviewInstance,
+            scale: scale,
+            configuration: configuration
+        )
         updateClockForVisibility(restartIfRunning: true)
     }
 
@@ -96,8 +111,30 @@ final class SplitFlapView: ScreenSaverView {
 
     override var isOpaque: Bool { true }
 
-    override var hasConfigureSheet: Bool { false }
-    override var configureSheet: NSWindow? { nil }
+    override var hasConfigureSheet: Bool { true }
+    override var configureSheet: NSWindow? {
+        let controller = SplitFlapConfigureSheetController(configuration: configuration) { [weak self] updated in
+            self?.applyConfiguration(updated)
+        }
+        configureSheetController = controller
+        return controller.window
+    }
+
+    private func applyConfiguration(_ updated: SplitFlapConfiguration) {
+        configuration = updated
+        SplitFlapConfigurationStore.save(updated)
+        rootLayer.backgroundColor = updated.theme.palette.screenBg
+
+        let scale = NSScreen.main?.backingScaleFactor ?? 2.0
+        grid?.rebuild(
+            bounds: bounds,
+            isPreview: isPreviewInstance,
+            scale: scale,
+            configuration: updated
+        )
+        clock?.update(configuration: updated)
+        updateClockForVisibility(restartIfRunning: true)
+    }
 
     private func observeCurrentWindow() {
         guard observedWindow !== window else { return }


### PR DESCRIPTION
## Summary

- Add a ScreenSaverDefaults-backed SplitFlap configuration model and AppKit options sheet.
- Add display modes for custom messages, clock, date, and random boards.
- Add Unicode grapheme rendering for custom display text while preserving mechanical forward-step animation for the original split-flap drum alphabet.
- Add configurable wave interval, idle shuffle, idle density, board rows, and theme.
- Seed System Settings preview content so the preview does not sit on a blank-looking micro-grid.

## Governing Issue

- No governing issue is linked. This PR comes from a direct user request in Codex.

## Validation

- [x] `git diff --check`
- [x] `bash scripts/ci/run-fast-checks.sh`
- [x] `make install`
- [x] Verified installed bundle metadata:
  - `CFBundleIdentifier => com.omt.SplitFlap`
  - `CFBundleName => SplitFlap`
  - `NSPrincipalClass => SplitFlap.SplitFlapView`

## Bootstrap Governance

- No bootstrap-controlled assets or `project.bootstrap.yaml` policy were changed.
- The Xcode project was updated only to include the new Swift source files in the target.

## Merge Automation

- Auto-merge is not safe to enable from this author because review is required and repo policy does not allow the PR author to approve their own PR.
- Fallback merge-readiness applies once required checks pass and review/conversation requirements are satisfied.

## Notes

- The previous fixed enum became a Unicode-capable value type. Known ASCII drum characters still use the old ordered mechanical sequence; arbitrary Unicode targets use a direct one-step flip.
- This target has no test bundle, so validation is build/install based.
- macOS may cache Screen Saver thumbnails; `make install` restarts `ScreenSaverEngine` to refresh the active bundle, but the Settings thumbnail may still require the pane to be reopened by the OS.
