### PR TITLE
Fix System Settings preview startup

### DIFF
--- a/SplitFlap/SplitFlapView.swift
+++ b/SplitFlap/SplitFlapView.swift
@@ -3,7 +3,7 @@ import QuartzCore
 import AppKit
 
 // The principal class loaded by macOS's screensaver engine.
-// Registered via NSPrincipalClass = "SplitFlap.SplitFlapView" in Info.plist.
+// Registered via NSPrincipalClass in Info.plist.
 @objc(SplitFlapView)
 final class SplitFlapView: ScreenSaverView {
 
@@ -169,6 +169,9 @@ final class SplitFlapView: ScreenSaverView {
 
     private var shouldRunClock: Bool {
         guard isAnimating, let window else { return false }
+        if isPreviewInstance {
+            return window.isVisible && !window.isMiniaturized
+        }
         return window.isVisible
             && !window.isMiniaturized
             && window.occlusionState.contains(.visible)


### PR DESCRIPTION
## Summary

- Fix the System Settings embedded preview staying blank by allowing preview instances to start when their host window is visible.
- Keep the stricter occlusion-state gate for the real full-screen screensaver path.
- Update the stale principal-class comment.

## Governing Issue

- No governing issue is linked; this is a follow-up from local preview verification after #35.

## Validation

- [x] `bash scripts/ci/run-fast-checks.sh` -> passed, `BUILD SUCCEEDED`
- [x] `make install` -> passed, installed `~/Library/Screen Savers/Flapline.saver`
- [x] `codesign --verify --deep --strict --verbose=2 ~/Library/Screen\ Savers/Flapline.saver` -> valid on disk, satisfies Designated Requirement
- [x] Installed Info.plist verified: `CFBundleIdentifier=app.flapline.screensaver`, `CFBundleName=Flapline`, `NSPrincipalClass=Flapline.SplitFlapView`

## Bootstrap Governance

- Not applicable; this change does not alter bootstrap files, GitHub policy, runner labels, or environment gates.

## Merge Automation

- Auto-merge is not enabled by the PR author because this PR still requires maintainer review after the new branch push.
- Fallback merge-readiness: merge after required checks pass and review requirements are satisfied.

## Notes

- Low risk. The behavior change is limited to `isPreview` instances in System Settings.
- Full-screen saver runtime keeps the existing `window.occlusionState.contains(.visible)` guard.
