### PR TITLE
Fix local Flapline screen saver install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,16 @@ BUILD_DIR     = build
 INSTALL_DIR   = $(HOME)/Library/Screen\ Savers
 SAVER_RELEASE = $(BUILD_DIR)/Build/Products/Release/$(PRODUCT_NAME).saver
 SAVER_DEBUG   = $(BUILD_DIR)/Build/Products/Debug/$(PRODUCT_NAME).saver
+INSTALLED_SAVER = $(HOME)/Library/Screen Savers/$(PRODUCT_NAME).saver
+SIGN_IDENTITY ?=
+DEVELOPMENT_TEAM ?=
+
+ifneq ($(SIGN_IDENTITY),)
+XCODE_SIGN_FLAGS = CODE_SIGN_IDENTITY="$(SIGN_IDENTITY)" CODE_SIGN_STYLE=Manual
+ifneq ($(DEVELOPMENT_TEAM),)
+XCODE_SIGN_FLAGS += DEVELOPMENT_TEAM=$(DEVELOPMENT_TEAM)
+endif
+endif
 
 .PHONY: all build debug install uninstall clean
 
@@ -17,6 +27,7 @@ build:
 		-configuration Release \
 		-derivedDataPath $(BUILD_DIR) \
 		ONLY_ACTIVE_ARCH=NO \
+		$(XCODE_SIGN_FLAGS) \
 		build
 
 debug:
@@ -25,12 +36,17 @@ debug:
 		-scheme $(SCHEME) \
 		-configuration Debug \
 		-derivedDataPath $(BUILD_DIR) \
+		$(XCODE_SIGN_FLAGS) \
 		build
 
 install: build
 	mkdir -p $(INSTALL_DIR)
 	rm -rf $(INSTALL_DIR)/$(PRODUCT_NAME).saver
 	cp -R "$(SAVER_RELEASE)" $(INSTALL_DIR)/
+	@if [ -n "$(SIGN_IDENTITY)" ]; then \
+		codesign --force --sign "$(SIGN_IDENTITY)" --timestamp=none "$(INSTALLED_SAVER)/Contents/MacOS/$(PRODUCT_NAME)"; \
+		codesign --force --sign "$(SIGN_IDENTITY)" --timestamp=none "$(INSTALLED_SAVER)"; \
+	fi
 	@echo "Installed to $(INSTALL_DIR)/$(PRODUCT_NAME).saver"
 	-killall ScreenSaverEngine 2>/dev/null; true
 
@@ -38,6 +54,10 @@ install-debug: debug
 	mkdir -p $(INSTALL_DIR)
 	rm -rf $(INSTALL_DIR)/$(PRODUCT_NAME).saver
 	cp -R "$(SAVER_DEBUG)" $(INSTALL_DIR)/
+	@if [ -n "$(SIGN_IDENTITY)" ]; then \
+		codesign --force --sign "$(SIGN_IDENTITY)" --timestamp=none "$(INSTALLED_SAVER)/Contents/MacOS/$(PRODUCT_NAME)"; \
+		codesign --force --sign "$(SIGN_IDENTITY)" --timestamp=none "$(INSTALLED_SAVER)"; \
+	fi
 	@echo "Installed debug build to $(INSTALL_DIR)/$(PRODUCT_NAME).saver"
 	-killall ScreenSaverEngine 2>/dev/null; true
 

--- a/SplitFlap/SplitFlapConfiguration.swift
+++ b/SplitFlap/SplitFlapConfiguration.swift
@@ -83,7 +83,7 @@ enum SplitFlapTheme: String, CaseIterable {
 
 struct SplitFlapConfiguration {
     var displayMode: SplitFlapDisplayMode = .messages
-    var messageText: String = "SplitFlap\nUnicode OK\nHello World"
+    var messageText: String = "Flapline\nUnicode OK\nHello World"
     var messageOrder: SplitFlapMessageOrder = .sequential
     var waveIntervalSeconds: TimeInterval = 8
     var idleShuffleEnabled: Bool = true
@@ -96,7 +96,7 @@ struct SplitFlapConfiguration {
             .split(whereSeparator: \.isNewline)
             .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines) }
             .filter { !$0.isEmpty }
-        return lines.isEmpty ? ["SplitFlap"] : lines
+        return lines.isEmpty ? ["Flapline"] : lines
     }
 
     func rowCount(isPreview: Bool) -> Int {
@@ -108,7 +108,7 @@ struct SplitFlapConfiguration {
 }
 
 enum SplitFlapConfigurationStore {
-    private static let moduleName = "com.omt.SplitFlap"
+    private static let moduleName = "app.flapline.screensaver"
 
     private enum Key {
         static let displayMode = "displayMode"
@@ -200,7 +200,7 @@ final class SplitFlapContentProvider {
         switch configuration.displayMode {
         case .random:
             if preview {
-                return textTargets(["SplitFlap"], rows: rows, cols: cols)
+                return textTargets(["Flapline"], rows: rows, cols: cols)
             }
             return randomTargets(rows: rows, cols: cols)
         case .messages:
@@ -222,7 +222,7 @@ final class SplitFlapContentProvider {
             }
             return message
         case .random:
-            return messages.randomElement() ?? "SplitFlap"
+            return messages.randomElement() ?? "Flapline"
         }
     }
 

--- a/SplitFlap/SplitFlapConfiguration.swift
+++ b/SplitFlap/SplitFlapConfiguration.swift
@@ -109,6 +109,7 @@ struct SplitFlapConfiguration {
 
 enum SplitFlapConfigurationStore {
     private static let moduleName = "app.flapline.screensaver"
+    private static let legacyModuleName = "com.omt.SplitFlap"
 
     private enum Key {
         static let displayMode = "displayMode"
@@ -119,6 +120,17 @@ enum SplitFlapConfigurationStore {
         static let idleDensity = "idleDensity"
         static let targetRows = "targetRows"
         static let theme = "theme"
+
+        static let all = [
+            displayMode,
+            messageText,
+            messageOrder,
+            waveIntervalSeconds,
+            idleShuffleEnabled,
+            idleDensity,
+            targetRows,
+            theme
+        ]
     }
 
     private static var defaults: UserDefaults {
@@ -128,6 +140,7 @@ enum SplitFlapConfigurationStore {
     static func load() -> SplitFlapConfiguration {
         let fallback = SplitFlapConfiguration()
         let defaults = defaults
+        migrateLegacyDefaultsIfNeeded(to: defaults)
         defaults.register(defaults: [
             Key.displayMode: fallback.displayMode.rawValue,
             Key.messageText: fallback.messageText,
@@ -162,6 +175,24 @@ enum SplitFlapConfigurationStore {
         defaults.set(configuration.targetRows, forKey: Key.targetRows)
         defaults.set(configuration.theme.rawValue, forKey: Key.theme)
         defaults.synchronize()
+    }
+
+    private static func migrateLegacyDefaultsIfNeeded(to defaults: UserDefaults) {
+        guard !hasSavedConfiguration(in: defaults),
+              let legacyDefaults = ScreenSaverDefaults(forModuleWithName: legacyModuleName),
+              hasSavedConfiguration(in: legacyDefaults)
+        else { return }
+
+        for key in Key.all {
+            if let value = legacyDefaults.object(forKey: key) {
+                defaults.set(value, forKey: key)
+            }
+        }
+        defaults.synchronize()
+    }
+
+    private static func hasSavedConfiguration(in defaults: UserDefaults) -> Bool {
+        Key.all.contains { defaults.object(forKey: $0) != nil }
     }
 
     private static func bounded(_ value: Double, min: Double, max: Double, fallback: Double) -> Double {

--- a/SplitFlap/SplitFlapConfigureSheetController.swift
+++ b/SplitFlap/SplitFlapConfigureSheetController.swift
@@ -34,7 +34,7 @@ final class SplitFlapConfigureSheetController: NSObject, NSWindowDelegate {
     }
 
     private func buildWindow() {
-        window.title = "SplitFlap Options"
+        window.title = "Flapline Options"
         window.isReleasedWhenClosed = false
         window.delegate = self
 


### PR DESCRIPTION
## Summary
- Add an opt-in signed local install path via `SIGN_IDENTITY` and optional `DEVELOPMENT_TEAM` so development installs can be accepted by the macOS screen saver host.
- Move persisted screen saver configuration from the old `com.omt.SplitFlap` module name to `app.flapline.screensaver`.
- Update remaining user-visible default/options labels from SplitFlap to Flapline.

## Governing Issue
- No governing issue; this is a follow-up to the local MacBook install/runtime failure found after PR #38 merged.

## Validation
- [x] `make clean install SIGN_IDENTITY="Apple Development: John TenEyck (499QUBUYSP)" DEVELOPMENT_TEAM=TFGKTMNSZV` passed locally and installed `~/Library/Screen Savers/Flapline.saver`.
- [x] `codesign --verify --verbose=4 "$HOME/Library/Screen Savers/Flapline.saver"` passed after the signed install path.
- [x] Launched `/System/Library/CoreServices/ScreenSaverEngine.app`; logs showed `legacyScreenSaver ... Setting module “Flapline”` with no fatal AMFI rejection for Flapline and no `com.omt.SplitFlap` preference-write error.
- [x] Verified the staged-only patch in a clean temporary worktree with `make build`.

## Bootstrap Governance
- Not applicable; this change does not alter bootstrap-managed policy, workflow, runner, or environment configuration.

## Merge Automation
- Auto-merge is not safe yet; wait for required CI and review on this PR, then use the fallback merge-readiness policy if auto-merge is unavailable.

## Notes
- Local installs without `SIGN_IDENTITY` still build/install as before for portability, but may be rejected by the macOS screen saver host on stricter systems.
- Public distribution still needs a notarized Developer ID release build.
