### PR TITLE
Fix Flapline message paging

### DIFF
--- a/SplitFlap/CharacterSet.swift
+++ b/SplitFlap/CharacterSet.swift
@@ -72,6 +72,11 @@ struct SplitFlapCharacter: Hashable {
         drumCharacters[Int.random(in: 0..<drumCharacters.count)]
     }
 
+    static func random(in alphabet: SplitFlapRandomAlphabet) -> SplitFlapCharacter {
+        let characters = alphabet.characters
+        return characters[Int.random(in: 0..<characters.count)]
+    }
+
     // Parse one extended grapheme cluster. Known ASCII drum characters normalize
     // to uppercase; all other Unicode clusters are preserved for rendering.
     static func from(_ string: String) -> SplitFlapCharacter {

--- a/SplitFlap/DisplayClock.swift
+++ b/SplitFlap/DisplayClock.swift
@@ -1,94 +1,25 @@
 import Foundation
 import QuartzCore
 import AppKit
-import CoreVideo
 
 private protocol DisplayTicker: AnyObject {
     func invalidate()
 }
 
-@available(macOS 14.0, *)
-private final class CADisplayTicker: NSObject, DisplayTicker {
-    private var link: CADisplayLink?
-    private var isInvalidated = false
-    private let onFrame: (CFTimeInterval) -> Void
+private final class TimerTicker: DisplayTicker {
+    private var timer: Timer?
 
-    init?(screen: NSScreen?, onFrame: @escaping (CFTimeInterval) -> Void) {
-        self.onFrame = onFrame
-        super.init()
-
-        guard let link = (screen ?? NSScreen.main)?.displayLink(
-            target: self,
-            selector: #selector(tick(_:))
-        ) else {
-            return nil
+    init(interval: TimeInterval, onFrame: @escaping (CFTimeInterval) -> Void) {
+        let timer = Timer(timeInterval: interval, repeats: true) { _ in
+            onFrame(CACurrentMediaTime())
         }
-        link.preferredFrameRateRange = CAFrameRateRange(
-            minimum: 6,
-            maximum: 15,
-            preferred: 10
-        )
-        link.add(to: .main, forMode: .common)
-        self.link = link
+        RunLoop.main.add(timer, forMode: .common)
+        self.timer = timer
     }
 
     func invalidate() {
-        isInvalidated = true
-        link?.invalidate()
-        link = nil
-    }
-
-    @objc private func tick(_ link: CADisplayLink) {
-        guard !isInvalidated else { return }
-        onFrame(link.targetTimestamp > 0 ? link.targetTimestamp : link.timestamp)
-    }
-}
-
-private final class CVDisplayTicker: DisplayTicker {
-    private var link: CVDisplayLink?
-    private var isInvalidated = false
-    private let onFrame: (CFTimeInterval) -> Void
-
-    init?(onFrame: @escaping (CFTimeInterval) -> Void) {
-        self.onFrame = onFrame
-
-        var link: CVDisplayLink?
-        guard CVDisplayLinkCreateWithActiveCGDisplays(&link) == kCVReturnSuccess,
-              let createdLink = link else {
-            return nil
-        }
-
-        self.link = createdLink
-        let context = Unmanaged.passUnretained(self).toOpaque()
-        CVDisplayLinkSetOutputCallback(createdLink, { _, now, _, _, _, context in
-            guard let context else { return kCVReturnSuccess }
-            let ticker = Unmanaged<CVDisplayTicker>.fromOpaque(context).takeUnretainedValue()
-            let scale = now.pointee.videoTimeScale
-            let timestamp: CFTimeInterval
-            if scale > 0 {
-                timestamp = CFTimeInterval(now.pointee.videoTime) / CFTimeInterval(scale)
-            } else {
-                timestamp = CACurrentMediaTime()
-            }
-            DispatchQueue.main.async { [weak ticker] in
-                guard let ticker, !ticker.isInvalidated else { return }
-                ticker.onFrame(timestamp)
-            }
-            return kCVReturnSuccess
-        }, context)
-        CVDisplayLinkStart(createdLink)
-    }
-
-    func invalidate() {
-        isInvalidated = true
-        if let link {
-            CVDisplayLinkStop(link)
-        }
-        link = nil
-    }
-
-    deinit {
-        invalidate()
+        timer?.invalidate()
+        timer = nil
     }
 }
 
@@ -121,6 +52,7 @@ final class DisplayClock: NSObject {
     private let maxIdleFlipStartsPerTick: Int = 12
     private let maxActiveIdleFlips: Int = 48
     private var runGeneration: Int = 0
+    private let tickerInterval: TimeInterval = 0.1
 
     // MARK: - Init
 
@@ -137,10 +69,15 @@ final class DisplayClock: NSObject {
         contentProvider.update(configuration: configuration)
     }
 
-    func showImmediateFrame() {
+    func showImmediateFrame(advanceMessages: Bool = false) {
         guard let grid else { return }
         applyTargets(
-            contentProvider.immediateTargets(rows: grid.rows, cols: grid.cols, preview: isPreview),
+            contentProvider.immediateTargets(
+                rows: grid.rows,
+                cols: grid.cols,
+                preview: isPreview,
+                advanceMessages: advanceMessages
+            ),
             grid: grid
         )
     }
@@ -161,7 +98,7 @@ final class DisplayClock: NSObject {
             isRunning = false
         }
 
-        showImmediateFrame()
+        showImmediateFrame(advanceMessages: true)
     }
 
     func stop() {
@@ -183,13 +120,7 @@ final class DisplayClock: NSObject {
     // MARK: - Tick
 
     private func makeTicker(screen: NSScreen?) -> DisplayTicker? {
-        if #available(macOS 14.0, *) {
-            return CADisplayTicker(screen: screen) { [weak self] timestamp in
-                self?.displayTick(timestamp: timestamp)
-            }
-        }
-
-        return CVDisplayTicker { [weak self] timestamp in
+        TimerTicker(interval: tickerInterval) { [weak self] timestamp in
             self?.displayTick(timestamp: timestamp)
         }
     }

--- a/SplitFlap/DisplayClock.swift
+++ b/SplitFlap/DisplayClock.swift
@@ -214,7 +214,7 @@ final class DisplayClock: NSObject {
 
             let panel = all[index]
             guard !panel.isFlipping else { continue }
-            let target = SplitFlapCharacter.random()
+            let target = SplitFlapCharacter.random(in: configuration.randomAlphabet)
             guard panel.currentCharacter != target else { continue }
             animator.animateTo(
                 target,

--- a/SplitFlap/DisplayClock.swift
+++ b/SplitFlap/DisplayClock.swift
@@ -24,9 +24,10 @@ private final class TimerTicker: DisplayTicker {
 }
 
 // Controls *when* and *which* panels flip.
-// Two phases alternate automatically:
-//   1. Idle shuffle — panels drift to random characters individually
-//   2. Wave update  — a left-to-right wave sweeps across all panels
+// Three phases cycle automatically:
+//   1. Hold        — completed message remains untouched
+//   2. Idle shuffle — panels drift to random characters individually
+//   3. Wave update  — a left-to-right wave sweeps across all panels
 final class DisplayClock: NSObject {
 
     private weak var grid: CharacterGrid?
@@ -43,6 +44,7 @@ final class DisplayClock: NSObject {
     private var isRunning = false
 
     private enum Phase {
+        case hold       // message remains fully visible
         case idle       // random individual flips
         case wave       // coordinated left-to-right wave
     }
@@ -88,7 +90,7 @@ final class DisplayClock: NSObject {
         stop()
         runGeneration += 1
         isRunning = true
-        phase = .idle
+        phase = .hold
         phaseTickCount = 0
         lastIdleTickTimestamp = nil
         lastClockTickTimestamp = nil
@@ -113,7 +115,7 @@ final class DisplayClock: NSObject {
                 panel.cancelFlip()
             }
         }
-        phase = .idle
+        phase = .hold
         phaseTickCount = 0
     }
 
@@ -154,6 +156,12 @@ final class DisplayClock: NSObject {
         phaseTickCount += 1
 
         switch phase {
+        case .hold:
+            if phaseTickCount >= holdTickDuration {
+                phase = .idle
+                phaseTickCount = 0
+            }
+
         case .idle:
             if configuration.idleShuffleEnabled {
                 idleTick(grid: grid)
@@ -168,7 +176,7 @@ final class DisplayClock: NSObject {
             // Wave animation timing is encoded in each panel's animation beginTime.
             // We just count ticks to know when to return to idle.
             if phaseTickCount >= waveTickDuration {
-                phase = .idle
+                phase = .hold
                 phaseTickCount = 0
             }
         }
@@ -259,16 +267,16 @@ final class DisplayClock: NSObject {
         startWave(grid: grid)
     }
 
-    private var cycleTickDuration: Int {
-        max(1, Int(configuration.waveIntervalSeconds / idleTickInterval))
+    private var holdTickDuration: Int {
+        max(0, Int(configuration.messageHoldSeconds / idleTickInterval))
     }
 
     private var idleTickDuration: Int {
-        max(1, cycleTickDuration - waveTickDuration)
+        max(1, Int(configuration.waveIntervalSeconds / idleTickInterval))
     }
 
     private var waveTickDuration: Int {
-        max(20, cycleTickDuration / 2)
+        max(20, Int(3 / idleTickInterval))
     }
 
     private func applyTargets(_ targets: [[SplitFlapCharacter]], grid: CharacterGrid) {

--- a/SplitFlap/SplitFlapConfiguration.swift
+++ b/SplitFlap/SplitFlapConfiguration.swift
@@ -30,6 +30,20 @@ enum SplitFlapMessageOrder: String, CaseIterable {
     }
 }
 
+enum SplitFlapMessageSource: String, CaseIterable {
+    case manual
+    case quoteFeed
+    case customURL
+
+    var title: String {
+        switch self {
+        case .manual: return "Manual"
+        case .quoteFeed: return "Quote Feed"
+        case .customURL: return "Custom URL"
+        }
+    }
+}
+
 enum SplitFlapRandomAlphabet: String, CaseIterable {
     case classic
     case latinExtended
@@ -146,7 +160,11 @@ enum SplitFlapTheme: String, CaseIterable {
 
 struct SplitFlapConfiguration {
     var displayMode: SplitFlapDisplayMode = .messages
+    var messageSource: SplitFlapMessageSource = .manual
     var messageText: String = "Flapline\nUnicode OK\nHello World"
+    var customMessageURL: String = ""
+    var contentRefreshSeconds: TimeInterval = 900
+    var fetchedMessageText: String = ""
     var messageOrder: SplitFlapMessageOrder = .sequential
     var messageHoldSeconds: TimeInterval = 4
     var waveIntervalSeconds: TimeInterval = 8
@@ -157,7 +175,15 @@ struct SplitFlapConfiguration {
     var theme: SplitFlapTheme = .classic
 
     var messages: [String] {
-        let lines = messageText
+        let sourceText: String
+        switch messageSource {
+        case .manual:
+            sourceText = messageText
+        case .quoteFeed, .customURL:
+            sourceText = fetchedMessageText.isEmpty ? messageText : fetchedMessageText
+        }
+
+        let lines = sourceText
             .split(whereSeparator: \.isNewline)
             .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines) }
             .filter { !$0.isEmpty }
@@ -175,10 +201,15 @@ struct SplitFlapConfiguration {
 enum SplitFlapConfigurationStore {
     private static let moduleName = "app.flapline.screensaver"
     private static let legacyModuleName = "com.omt.SplitFlap"
+    private static let cachedFeedMessagesKey = "cachedFeedMessages"
+    private static let cachedFeedURLKey = "cachedFeedURL"
 
     private enum Key {
         static let displayMode = "displayMode"
+        static let messageSource = "messageSource"
         static let messageText = "messageText"
+        static let customMessageURL = "customMessageURL"
+        static let contentRefreshSeconds = "contentRefreshSeconds"
         static let messageOrder = "messageOrder"
         static let messageHoldSeconds = "messageHoldSeconds"
         static let waveIntervalSeconds = "waveIntervalSeconds"
@@ -190,7 +221,10 @@ enum SplitFlapConfigurationStore {
 
         static let all = [
             displayMode,
+            messageSource,
             messageText,
+            customMessageURL,
+            contentRefreshSeconds,
             messageOrder,
             messageHoldSeconds,
             waveIntervalSeconds,
@@ -212,7 +246,10 @@ enum SplitFlapConfigurationStore {
         migrateLegacyDefaultsIfNeeded(to: defaults)
         defaults.register(defaults: [
             Key.displayMode: fallback.displayMode.rawValue,
+            Key.messageSource: fallback.messageSource.rawValue,
             Key.messageText: fallback.messageText,
+            Key.customMessageURL: fallback.customMessageURL,
+            Key.contentRefreshSeconds: fallback.contentRefreshSeconds,
             Key.messageOrder: fallback.messageOrder.rawValue,
             Key.messageHoldSeconds: fallback.messageHoldSeconds,
             Key.waveIntervalSeconds: fallback.waveIntervalSeconds,
@@ -225,7 +262,10 @@ enum SplitFlapConfigurationStore {
 
         return SplitFlapConfiguration(
             displayMode: SplitFlapDisplayMode(rawValue: defaults.string(forKey: Key.displayMode) ?? "") ?? fallback.displayMode,
+            messageSource: SplitFlapMessageSource(rawValue: defaults.string(forKey: Key.messageSource) ?? "") ?? fallback.messageSource,
             messageText: defaults.string(forKey: Key.messageText) ?? fallback.messageText,
+            customMessageURL: defaults.string(forKey: Key.customMessageURL) ?? fallback.customMessageURL,
+            contentRefreshSeconds: bounded(defaults.double(forKey: Key.contentRefreshSeconds), min: 60, max: 86_400, fallback: fallback.contentRefreshSeconds),
             messageOrder: SplitFlapMessageOrder(rawValue: defaults.string(forKey: Key.messageOrder) ?? "") ?? fallback.messageOrder,
             messageHoldSeconds: bounded(defaults.double(forKey: Key.messageHoldSeconds), min: 0, max: 30, fallback: fallback.messageHoldSeconds),
             waveIntervalSeconds: bounded(defaults.double(forKey: Key.waveIntervalSeconds), min: 2, max: 60, fallback: fallback.waveIntervalSeconds),
@@ -240,7 +280,10 @@ enum SplitFlapConfigurationStore {
     static func save(_ configuration: SplitFlapConfiguration) {
         let defaults = defaults
         defaults.set(configuration.displayMode.rawValue, forKey: Key.displayMode)
+        defaults.set(configuration.messageSource.rawValue, forKey: Key.messageSource)
         defaults.set(configuration.messageText, forKey: Key.messageText)
+        defaults.set(configuration.customMessageURL, forKey: Key.customMessageURL)
+        defaults.set(configuration.contentRefreshSeconds, forKey: Key.contentRefreshSeconds)
         defaults.set(configuration.messageOrder.rawValue, forKey: Key.messageOrder)
         defaults.set(configuration.messageHoldSeconds, forKey: Key.messageHoldSeconds)
         defaults.set(configuration.waveIntervalSeconds, forKey: Key.waveIntervalSeconds)
@@ -249,6 +292,19 @@ enum SplitFlapConfigurationStore {
         defaults.set(configuration.idleDensity, forKey: Key.idleDensity)
         defaults.set(configuration.targetRows, forKey: Key.targetRows)
         defaults.set(configuration.theme.rawValue, forKey: Key.theme)
+        defaults.synchronize()
+    }
+
+    static func cachedFeedMessages(for url: URL) -> String {
+        let defaults = defaults
+        guard defaults.string(forKey: cachedFeedURLKey) == url.absoluteString else { return "" }
+        return defaults.string(forKey: cachedFeedMessagesKey) ?? ""
+    }
+
+    static func saveCachedFeedMessages(_ messages: [String], for url: URL) {
+        let defaults = defaults
+        defaults.set(url.absoluteString, forKey: cachedFeedURLKey)
+        defaults.set(messages.joined(separator: "\n"), forKey: cachedFeedMessagesKey)
         defaults.synchronize()
     }
 
@@ -273,6 +329,141 @@ enum SplitFlapConfigurationStore {
     private static func bounded(_ value: Double, min: Double, max: Double, fallback: Double) -> Double {
         guard value.isFinite, value >= min, value <= max else { return fallback }
         return value
+    }
+}
+
+final class SplitFlapMessageFeedLoader {
+    private var task: URLSessionDataTask?
+
+    func cancel() {
+        task?.cancel()
+        task = nil
+    }
+
+    func load(
+        configuration: SplitFlapConfiguration,
+        completion: @escaping ([String]) -> Void
+    ) {
+        cancel()
+
+        guard let url = feedURL(for: configuration) else {
+            completion([])
+            return
+        }
+
+        let cached = SplitFlapConfigurationStore.cachedFeedMessages(for: url)
+        if !cached.isEmpty {
+            completion(Self.lines(in: cached))
+        }
+
+        var request = URLRequest(url: url)
+        request.cachePolicy = .reloadIgnoringLocalCacheData
+        request.timeoutInterval = 10
+
+        task = URLSession.shared.dataTask(with: request) { data, _, error in
+            guard error == nil,
+                  let data,
+                  let messages = Self.messages(from: data),
+                  !messages.isEmpty
+            else { return }
+
+            SplitFlapConfigurationStore.saveCachedFeedMessages(messages, for: url)
+            DispatchQueue.main.async {
+                completion(messages)
+            }
+        }
+        task?.resume()
+    }
+
+    private func feedURL(for configuration: SplitFlapConfiguration) -> URL? {
+        switch configuration.messageSource {
+        case .manual:
+            return nil
+        case .quoteFeed:
+            return URL(string: "https://zenquotes.io/api/quotes")
+        case .customURL:
+            let trimmed = configuration.customMessageURL.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard let url = URL(string: trimmed),
+                  let scheme = url.scheme?.lowercased(),
+                  scheme == "http" || scheme == "https"
+            else { return nil }
+            return url
+        }
+    }
+
+    private static func messages(from data: Data) -> [String]? {
+        guard let json = try? JSONSerialization.jsonObject(with: data) else { return nil }
+        return messages(from: json).map { Array($0.prefix(50)) }
+    }
+
+    private static func messages(from json: Any) -> [String]? {
+        if let dictionary = json as? [String: Any] {
+            if let messages = dictionary["messages"] as? [String] {
+                return clean(messages)
+            }
+
+            if let content = dictionary["content"] as? String {
+                return clean([joinedQuote(content: content, author: dictionary["author"] as? String)])
+            }
+
+            if let quote = dictionary["quote"] as? String {
+                return clean([joinedQuote(content: quote, author: dictionary["author"] as? String)])
+            }
+
+            if let text = dictionary["text"] as? String {
+                return clean([text])
+            }
+
+            if let data = dictionary["data"] {
+                return messages(from: data)
+            }
+        }
+
+        if let array = json as? [Any] {
+            let parsed = array.compactMap { item -> String? in
+                if let string = item as? String {
+                    return string
+                }
+
+                guard let dictionary = item as? [String: Any] else { return nil }
+                if let message = dictionary["message"] as? String {
+                    return message
+                }
+                if let content = dictionary["content"] as? String {
+                    return joinedQuote(content: content, author: dictionary["author"] as? String)
+                }
+                if let quote = dictionary["quote"] as? String {
+                    return joinedQuote(content: quote, author: dictionary["author"] as? String)
+                }
+                if let quote = dictionary["q"] as? String {
+                    return joinedQuote(content: quote, author: dictionary["a"] as? String)
+                }
+                if let text = dictionary["text"] as? String {
+                    return text
+                }
+                return nil
+            }
+            return clean(parsed)
+        }
+
+        return nil
+    }
+
+    private static func joinedQuote(content: String, author: String?) -> String {
+        guard let author,
+              !author.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else { return content }
+        return "\(content) - \(author)"
+    }
+
+    private static func clean(_ messages: [String]) -> [String] {
+        messages
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+    }
+
+    private static func lines(in text: String) -> [String] {
+        text.split(whereSeparator: \.isNewline).map(String.init)
     }
 }
 

--- a/SplitFlap/SplitFlapConfiguration.swift
+++ b/SplitFlap/SplitFlapConfiguration.swift
@@ -85,6 +85,7 @@ struct SplitFlapConfiguration {
     var displayMode: SplitFlapDisplayMode = .messages
     var messageText: String = "Flapline\nUnicode OK\nHello World"
     var messageOrder: SplitFlapMessageOrder = .sequential
+    var messageHoldSeconds: TimeInterval = 4
     var waveIntervalSeconds: TimeInterval = 8
     var idleShuffleEnabled: Bool = true
     var idleDensity: Double = 0.04
@@ -115,6 +116,7 @@ enum SplitFlapConfigurationStore {
         static let displayMode = "displayMode"
         static let messageText = "messageText"
         static let messageOrder = "messageOrder"
+        static let messageHoldSeconds = "messageHoldSeconds"
         static let waveIntervalSeconds = "waveIntervalSeconds"
         static let idleShuffleEnabled = "idleShuffleEnabled"
         static let idleDensity = "idleDensity"
@@ -125,6 +127,7 @@ enum SplitFlapConfigurationStore {
             displayMode,
             messageText,
             messageOrder,
+            messageHoldSeconds,
             waveIntervalSeconds,
             idleShuffleEnabled,
             idleDensity,
@@ -145,6 +148,7 @@ enum SplitFlapConfigurationStore {
             Key.displayMode: fallback.displayMode.rawValue,
             Key.messageText: fallback.messageText,
             Key.messageOrder: fallback.messageOrder.rawValue,
+            Key.messageHoldSeconds: fallback.messageHoldSeconds,
             Key.waveIntervalSeconds: fallback.waveIntervalSeconds,
             Key.idleShuffleEnabled: fallback.idleShuffleEnabled,
             Key.idleDensity: fallback.idleDensity,
@@ -156,6 +160,7 @@ enum SplitFlapConfigurationStore {
             displayMode: SplitFlapDisplayMode(rawValue: defaults.string(forKey: Key.displayMode) ?? "") ?? fallback.displayMode,
             messageText: defaults.string(forKey: Key.messageText) ?? fallback.messageText,
             messageOrder: SplitFlapMessageOrder(rawValue: defaults.string(forKey: Key.messageOrder) ?? "") ?? fallback.messageOrder,
+            messageHoldSeconds: bounded(defaults.double(forKey: Key.messageHoldSeconds), min: 0, max: 30, fallback: fallback.messageHoldSeconds),
             waveIntervalSeconds: bounded(defaults.double(forKey: Key.waveIntervalSeconds), min: 2, max: 60, fallback: fallback.waveIntervalSeconds),
             idleShuffleEnabled: defaults.object(forKey: Key.idleShuffleEnabled) as? Bool ?? fallback.idleShuffleEnabled,
             idleDensity: bounded(defaults.double(forKey: Key.idleDensity), min: 0, max: 0.2, fallback: fallback.idleDensity),
@@ -169,6 +174,7 @@ enum SplitFlapConfigurationStore {
         defaults.set(configuration.displayMode.rawValue, forKey: Key.displayMode)
         defaults.set(configuration.messageText, forKey: Key.messageText)
         defaults.set(configuration.messageOrder.rawValue, forKey: Key.messageOrder)
+        defaults.set(configuration.messageHoldSeconds, forKey: Key.messageHoldSeconds)
         defaults.set(configuration.waveIntervalSeconds, forKey: Key.waveIntervalSeconds)
         defaults.set(configuration.idleShuffleEnabled, forKey: Key.idleShuffleEnabled)
         defaults.set(configuration.idleDensity, forKey: Key.idleDensity)

--- a/SplitFlap/SplitFlapConfiguration.swift
+++ b/SplitFlap/SplitFlapConfiguration.swift
@@ -30,6 +30,69 @@ enum SplitFlapMessageOrder: String, CaseIterable {
     }
 }
 
+enum SplitFlapRandomAlphabet: String, CaseIterable {
+    case classic
+    case latinExtended
+    case cyrillic
+    case greek
+    case arabic
+    case mixedWorld
+
+    var title: String {
+        switch self {
+        case .classic: return "Classic"
+        case .latinExtended: return "Latin Extended"
+        case .cyrillic: return "Cyrillic"
+        case .greek: return "Greek"
+        case .arabic: return "Arabic"
+        case .mixedWorld: return "Mixed World"
+        }
+    }
+
+    var characters: [SplitFlapCharacter] {
+        switch self {
+        case .classic:
+            return SplitFlapCharacter.drumCharacters
+        case .latinExtended:
+            return Self.makeCharacters(
+                " ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.,-/:"
+                + "ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÑÒÓÔÕÖØÙÚÛÜÝ"
+                + "àáâãäåæçèéêëìíîïñòóôõöøùúûüýÿ"
+            )
+        case .cyrillic:
+            return Self.makeCharacters(
+                " АБВГДЕЁЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯ"
+                + "абвгдеёжзийклмнопрстуфхцчшщъыьэюя"
+            )
+        case .greek:
+            return Self.makeCharacters(
+                " ΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡΣΤΥΦΧΨΩ"
+                + "αβγδεζηθικλμνξοπρστυφχψω"
+                + "άέήίόύώϊϋΐΰ"
+            )
+        case .arabic:
+            return Self.makeCharacters(" ابتثجحخدذرزسشصضطظعغفقكلمنهويءآأؤإئىة")
+        case .mixedWorld:
+            return Self.unique(
+                SplitFlapCharacter.drumCharacters
+                + SplitFlapRandomAlphabet.latinExtended.characters
+                + SplitFlapRandomAlphabet.cyrillic.characters
+                + SplitFlapRandomAlphabet.greek.characters
+                + SplitFlapRandomAlphabet.arabic.characters
+            )
+        }
+    }
+
+    private static func makeCharacters(_ string: String) -> [SplitFlapCharacter] {
+        unique(string.map { SplitFlapCharacter(String($0)) })
+    }
+
+    private static func unique(_ characters: [SplitFlapCharacter]) -> [SplitFlapCharacter] {
+        var seen = Set<SplitFlapCharacter>()
+        return characters.filter { seen.insert($0).inserted }
+    }
+}
+
 struct SplitFlapPalette {
     let identifier: String
     let panelBackground: CGColor
@@ -87,6 +150,7 @@ struct SplitFlapConfiguration {
     var messageOrder: SplitFlapMessageOrder = .sequential
     var messageHoldSeconds: TimeInterval = 4
     var waveIntervalSeconds: TimeInterval = 8
+    var randomAlphabet: SplitFlapRandomAlphabet = .classic
     var idleShuffleEnabled: Bool = true
     var idleDensity: Double = 0.04
     var targetRows: Int = 9
@@ -118,6 +182,7 @@ enum SplitFlapConfigurationStore {
         static let messageOrder = "messageOrder"
         static let messageHoldSeconds = "messageHoldSeconds"
         static let waveIntervalSeconds = "waveIntervalSeconds"
+        static let randomAlphabet = "randomAlphabet"
         static let idleShuffleEnabled = "idleShuffleEnabled"
         static let idleDensity = "idleDensity"
         static let targetRows = "targetRows"
@@ -129,6 +194,7 @@ enum SplitFlapConfigurationStore {
             messageOrder,
             messageHoldSeconds,
             waveIntervalSeconds,
+            randomAlphabet,
             idleShuffleEnabled,
             idleDensity,
             targetRows,
@@ -150,6 +216,7 @@ enum SplitFlapConfigurationStore {
             Key.messageOrder: fallback.messageOrder.rawValue,
             Key.messageHoldSeconds: fallback.messageHoldSeconds,
             Key.waveIntervalSeconds: fallback.waveIntervalSeconds,
+            Key.randomAlphabet: fallback.randomAlphabet.rawValue,
             Key.idleShuffleEnabled: fallback.idleShuffleEnabled,
             Key.idleDensity: fallback.idleDensity,
             Key.targetRows: fallback.targetRows,
@@ -162,6 +229,7 @@ enum SplitFlapConfigurationStore {
             messageOrder: SplitFlapMessageOrder(rawValue: defaults.string(forKey: Key.messageOrder) ?? "") ?? fallback.messageOrder,
             messageHoldSeconds: bounded(defaults.double(forKey: Key.messageHoldSeconds), min: 0, max: 30, fallback: fallback.messageHoldSeconds),
             waveIntervalSeconds: bounded(defaults.double(forKey: Key.waveIntervalSeconds), min: 2, max: 60, fallback: fallback.waveIntervalSeconds),
+            randomAlphabet: SplitFlapRandomAlphabet(rawValue: defaults.string(forKey: Key.randomAlphabet) ?? "") ?? fallback.randomAlphabet,
             idleShuffleEnabled: defaults.object(forKey: Key.idleShuffleEnabled) as? Bool ?? fallback.idleShuffleEnabled,
             idleDensity: bounded(defaults.double(forKey: Key.idleDensity), min: 0, max: 0.2, fallback: fallback.idleDensity),
             targetRows: min(max(defaults.integer(forKey: Key.targetRows), 4), 24),
@@ -176,6 +244,7 @@ enum SplitFlapConfigurationStore {
         defaults.set(configuration.messageOrder.rawValue, forKey: Key.messageOrder)
         defaults.set(configuration.messageHoldSeconds, forKey: Key.messageHoldSeconds)
         defaults.set(configuration.waveIntervalSeconds, forKey: Key.waveIntervalSeconds)
+        defaults.set(configuration.randomAlphabet.rawValue, forKey: Key.randomAlphabet)
         defaults.set(configuration.idleShuffleEnabled, forKey: Key.idleShuffleEnabled)
         defaults.set(configuration.idleDensity, forKey: Key.idleDensity)
         defaults.set(configuration.targetRows, forKey: Key.targetRows)
@@ -293,7 +362,7 @@ final class SplitFlapContentProvider {
 
     private func randomTargets(rows: Int, cols: Int) -> [[SplitFlapCharacter]] {
         (0..<rows).map { _ in
-            (0..<cols).map { _ in SplitFlapCharacter.random() }
+            (0..<cols).map { _ in SplitFlapCharacter.random(in: configuration.randomAlphabet) }
         }
     }
 

--- a/SplitFlap/SplitFlapConfiguration.swift
+++ b/SplitFlap/SplitFlapConfiguration.swift
@@ -204,6 +204,7 @@ enum SplitFlapConfigurationStore {
 final class SplitFlapContentProvider {
     private var configuration: SplitFlapConfiguration
     private var messageIndex = 0
+    private var messagePageIndex = 0
 
     init(configuration: SplitFlapConfiguration) {
         self.configuration = configuration
@@ -212,14 +213,20 @@ final class SplitFlapContentProvider {
     func update(configuration: SplitFlapConfiguration) {
         self.configuration = configuration
         messageIndex = min(messageIndex, max(configuration.messages.count - 1, 0))
+        messagePageIndex = 0
     }
 
     func nextTargets(rows: Int, cols: Int, preview: Bool = false) -> [[SplitFlapCharacter]] {
         targets(rows: rows, cols: cols, preview: preview, advanceMessages: true)
     }
 
-    func immediateTargets(rows: Int, cols: Int, preview: Bool = false) -> [[SplitFlapCharacter]] {
-        targets(rows: rows, cols: cols, preview: preview, advanceMessages: false)
+    func immediateTargets(
+        rows: Int,
+        cols: Int,
+        preview: Bool = false,
+        advanceMessages: Bool = false
+    ) -> [[SplitFlapCharacter]] {
+        targets(rows: rows, cols: cols, preview: preview, advanceMessages: advanceMessages)
     }
 
     private func targets(
@@ -235,7 +242,7 @@ final class SplitFlapContentProvider {
             }
             return randomTargets(rows: rows, cols: cols)
         case .messages:
-            return textTargets([message(advance: advanceMessages)], rows: rows, cols: cols)
+            return textTargets(messagePage(advance: advanceMessages, rows: rows, cols: cols), rows: rows, cols: cols)
         case .clock:
             return textTargets([Self.clockFormatter.string(from: Date())], rows: rows, cols: cols)
         case .date:
@@ -243,17 +250,38 @@ final class SplitFlapContentProvider {
         }
     }
 
-    private func message(advance: Bool) -> String {
+    private func messagePage(advance: Bool, rows: Int, cols: Int) -> [[SplitFlapCharacter]] {
         let messages = configuration.messages
+        let message: String
         switch configuration.messageOrder {
         case .sequential:
-            let message = messages[messageIndex % messages.count]
-            if advance {
-                messageIndex = (messageIndex + 1) % messages.count
-            }
-            return message
+            message = messages[messageIndex % messages.count]
         case .random:
-            return messages.randomElement() ?? "Flapline"
+            message = messages.randomElement() ?? "Flapline"
+        }
+
+        let pageRows = pagedLines(message, rows: rows, cols: cols)
+        let currentPage = min(messagePageIndex, max(pageRows.count - 1, 0))
+        let visiblePage = pageRows.isEmpty ? [[SplitFlapCharacter.space]] : pageRows[currentPage]
+
+        if advance {
+            advanceMessageCursor(pageCount: max(pageRows.count, 1))
+        }
+
+        return visiblePage
+    }
+
+    private func advanceMessageCursor(pageCount: Int) {
+        switch configuration.messageOrder {
+        case .sequential:
+            if messagePageIndex + 1 < pageCount {
+                messagePageIndex += 1
+            } else {
+                messagePageIndex = 0
+                messageIndex = (messageIndex + 1) % configuration.messages.count
+            }
+        case .random:
+            messagePageIndex = 0
         }
     }
 
@@ -264,19 +292,26 @@ final class SplitFlapContentProvider {
     }
 
     private func textTargets(_ textLines: [String], rows: Int, cols: Int) -> [[SplitFlapCharacter]] {
+        textTargets(textLines.map { SplitFlapCharacter.characters(in: $0) }, rows: rows, cols: cols)
+    }
+
+    private func textTargets(_ textLines: [[SplitFlapCharacter]], rows: Int, cols: Int) -> [[SplitFlapCharacter]] {
         var targets = Array(
             repeating: Array(repeating: SplitFlapCharacter.space, count: cols),
             count: rows
         )
         guard rows > 0, cols > 0 else { return targets }
 
-        let wrapped = textLines.flatMap { wrappedLines($0, maxWidth: cols) }
-        let visibleLines = Array(wrapped.prefix(rows))
-        let startRow = max(0, (rows - visibleLines.count) / 2)
+        let inset = textInset(rows: rows, cols: cols)
+        let contentRows = max(1, rows - inset * 2)
+        let contentCols = max(1, cols - inset * 2)
+        let wrapped = textLines.flatMap { wrappedLines($0, maxWidth: contentCols) }
+        let visibleLines = Array(wrapped.prefix(contentRows))
+        let startRow = inset + max(0, (contentRows - visibleLines.count) / 2)
 
         for (offset, line) in visibleLines.enumerated() {
-            let characters = Array(line.prefix(cols))
-            let startCol = max(0, (cols - characters.count) / 2)
+            let characters = Array(line.prefix(contentCols))
+            let startCol = inset + max(0, (contentCols - characters.count) / 2)
             for (index, character) in characters.enumerated() {
                 targets[startRow + offset][startCol + index] = character
             }
@@ -285,8 +320,24 @@ final class SplitFlapContentProvider {
         return targets
     }
 
+    private func pagedLines(_ text: String, rows: Int, cols: Int) -> [[[SplitFlapCharacter]]] {
+        let inset = textInset(rows: rows, cols: cols)
+        let contentRows = max(1, rows - inset * 2)
+        let contentCols = max(1, cols - inset * 2)
+        let wrapped = wrappedLines(text, maxWidth: contentCols)
+        guard !wrapped.isEmpty else { return [[[.space]]] }
+
+        return stride(from: 0, to: wrapped.count, by: contentRows).map { start in
+            Array(wrapped[start..<min(start + contentRows, wrapped.count)])
+        }
+    }
+
     private func wrappedLines(_ text: String, maxWidth: Int) -> [[SplitFlapCharacter]] {
         let characters = SplitFlapCharacter.characters(in: text)
+        return wrappedLines(characters, maxWidth: maxWidth)
+    }
+
+    private func wrappedLines(_ characters: [SplitFlapCharacter], maxWidth: Int) -> [[SplitFlapCharacter]] {
         guard !characters.isEmpty else { return [[.space]] }
         guard maxWidth > 0 else { return [] }
 
@@ -298,6 +349,10 @@ final class SplitFlapContentProvider {
             index = end
         }
         return lines
+    }
+
+    private func textInset(rows: Int, cols: Int) -> Int {
+        rows > 2 && cols > 2 ? 1 : 0
     }
 
     private static let clockFormatter: DateFormatter = {

--- a/SplitFlap/SplitFlapConfiguration.swift
+++ b/SplitFlap/SplitFlapConfiguration.swift
@@ -480,6 +480,9 @@ final class SplitFlapContentProvider {
         self.configuration = configuration
         messageIndex = min(messageIndex, max(configuration.messages.count - 1, 0))
         messagePageIndex = 0
+        if configuration.messageOrder == .random {
+            messageIndex = randomMessageIndex(messageCount: configuration.messages.count)
+        }
     }
 
     func nextTargets(rows: Int, cols: Int, preview: Bool = false) -> [[SplitFlapCharacter]] {
@@ -518,13 +521,7 @@ final class SplitFlapContentProvider {
 
     private func messagePage(advance: Bool, rows: Int, cols: Int) -> [[SplitFlapCharacter]] {
         let messages = configuration.messages
-        let message: String
-        switch configuration.messageOrder {
-        case .sequential:
-            message = messages[messageIndex % messages.count]
-        case .random:
-            message = messages.randomElement() ?? "Flapline"
-        }
+        let message = messages[messageIndex % messages.count]
 
         let pageRows = pagedLines(message, rows: rows, cols: cols)
         let currentPage = min(messagePageIndex, max(pageRows.count - 1, 0))
@@ -538,17 +535,31 @@ final class SplitFlapContentProvider {
     }
 
     private func advanceMessageCursor(pageCount: Int) {
+        if messagePageIndex + 1 < pageCount {
+            messagePageIndex += 1
+            return
+        }
+
+        messagePageIndex = 0
         switch configuration.messageOrder {
         case .sequential:
-            if messagePageIndex + 1 < pageCount {
-                messagePageIndex += 1
-            } else {
-                messagePageIndex = 0
-                messageIndex = (messageIndex + 1) % configuration.messages.count
-            }
+            messageIndex = (messageIndex + 1) % configuration.messages.count
         case .random:
-            messagePageIndex = 0
+            messageIndex = randomMessageIndex(messageCount: configuration.messages.count, excluding: messageIndex)
         }
+    }
+
+    private func randomMessageIndex(messageCount: Int, excluding currentIndex: Int? = nil) -> Int {
+        guard messageCount > 1 else { return 0 }
+        guard let currentIndex else {
+            return Int.random(in: 0..<messageCount)
+        }
+
+        var nextIndex = currentIndex
+        while nextIndex == currentIndex {
+            nextIndex = Int.random(in: 0..<messageCount)
+        }
+        return nextIndex
     }
 
     private func randomTargets(rows: Int, cols: Int) -> [[SplitFlapCharacter]] {

--- a/SplitFlap/SplitFlapConfigureSheetController.swift
+++ b/SplitFlap/SplitFlapConfigureSheetController.swift
@@ -8,7 +8,11 @@ final class SplitFlapConfigureSheetController: NSObject, NSWindowDelegate {
     var onClose: (() -> Void)?
 
     private let modePopup = NSPopUpButton()
+    private let messageSourcePopup = NSPopUpButton()
     private let messageTextView = NSTextView()
+    private let customURLField = NSTextField()
+    private let refreshSlider = NSSlider(value: 15, minValue: 1, maxValue: 1440, target: nil, action: nil)
+    private let refreshValueLabel = NSTextField(labelWithString: "")
     private let orderPopup = NSPopUpButton()
     private let holdSlider = NSSlider(value: 4, minValue: 0, maxValue: 30, target: nil, action: nil)
     private let holdValueLabel = NSTextField(labelWithString: "")
@@ -26,7 +30,7 @@ final class SplitFlapConfigureSheetController: NSObject, NSWindowDelegate {
         self.configuration = configuration
         self.onSave = onSave
         self.window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 560, height: 600),
+            contentRect: NSRect(x: 0, y: 0, width: 560, height: 700),
             styleMask: [.titled],
             backing: .buffered,
             defer: false
@@ -53,6 +57,7 @@ final class SplitFlapConfigureSheetController: NSObject, NSWindowDelegate {
         contentView.addSubview(stack)
 
         modePopup.addItems(withTitles: SplitFlapDisplayMode.allCases.map(\.title))
+        messageSourcePopup.addItems(withTitles: SplitFlapMessageSource.allCases.map(\.title))
         orderPopup.addItems(withTitles: SplitFlapMessageOrder.allCases.map(\.title))
         randomAlphabetPopup.addItems(withTitles: SplitFlapRandomAlphabet.allCases.map(\.title))
         themePopup.addItems(withTitles: SplitFlapTheme.allCases.map(\.title))
@@ -66,6 +71,9 @@ final class SplitFlapConfigureSheetController: NSObject, NSWindowDelegate {
         messageTextView.textContainer?.widthTracksTextView = true
         messageTextView.font = .systemFont(ofSize: 13)
         messageTextView.frame = NSRect(x: 0, y: 0, width: 500, height: 120)
+        customURLField.placeholderString = "https://example.com/flapline.json"
+        customURLField.translatesAutoresizingMaskIntoConstraints = false
+        customURLField.widthAnchor.constraint(equalToConstant: 360).isActive = true
 
         let scrollView = NSScrollView()
         scrollView.borderType = .bezelBorder
@@ -75,7 +83,7 @@ final class SplitFlapConfigureSheetController: NSObject, NSWindowDelegate {
         scrollView.heightAnchor.constraint(equalToConstant: 130).isActive = true
         scrollView.widthAnchor.constraint(equalToConstant: 500).isActive = true
 
-        [holdSlider, waveSlider, idleDensitySlider, rowsSlider].forEach {
+        [refreshSlider, holdSlider, waveSlider, idleDensitySlider, rowsSlider].forEach {
             $0.translatesAutoresizingMaskIntoConstraints = false
             $0.target = self
             $0.action = #selector(sliderChanged(_:))
@@ -83,7 +91,10 @@ final class SplitFlapConfigureSheetController: NSObject, NSWindowDelegate {
         }
 
         stack.addArrangedSubview(row(label: "Display", control: modePopup))
+        stack.addArrangedSubview(row(label: "Message source", control: messageSourcePopup))
         stack.addArrangedSubview(labeledBlock(label: "Messages", control: scrollView))
+        stack.addArrangedSubview(row(label: "Custom URL", control: customURLField))
+        stack.addArrangedSubview(sliderRow(label: "Refresh", slider: refreshSlider, valueLabel: refreshValueLabel))
         stack.addArrangedSubview(row(label: "Message order", control: orderPopup))
         stack.addArrangedSubview(sliderRow(label: "Message hold", slider: holdSlider, valueLabel: holdValueLabel))
         stack.addArrangedSubview(sliderRow(label: "Idle interval", slider: waveSlider, valueLabel: waveValueLabel))
@@ -120,7 +131,10 @@ final class SplitFlapConfigureSheetController: NSObject, NSWindowDelegate {
 
     private func loadConfiguration() {
         modePopup.selectItem(at: SplitFlapDisplayMode.allCases.firstIndex(of: configuration.displayMode) ?? 0)
+        messageSourcePopup.selectItem(at: SplitFlapMessageSource.allCases.firstIndex(of: configuration.messageSource) ?? 0)
         messageTextView.string = configuration.messageText
+        customURLField.stringValue = configuration.customMessageURL
+        refreshSlider.doubleValue = configuration.contentRefreshSeconds / 60
         orderPopup.selectItem(at: SplitFlapMessageOrder.allCases.firstIndex(of: configuration.messageOrder) ?? 0)
         holdSlider.doubleValue = configuration.messageHoldSeconds
         waveSlider.doubleValue = configuration.waveIntervalSeconds
@@ -165,6 +179,7 @@ final class SplitFlapConfigureSheetController: NSObject, NSWindowDelegate {
     }
 
     private func updateValueLabels() {
+        refreshValueLabel.stringValue = "\(Int(refreshSlider.doubleValue.rounded())) min"
         holdValueLabel.stringValue = "\(Int(holdSlider.doubleValue.rounded())) sec"
         waveValueLabel.stringValue = "\(Int(waveSlider.doubleValue.rounded())) sec"
         idleDensityValueLabel.stringValue = "\(Int((idleDensitySlider.doubleValue * 100).rounded()))%"
@@ -173,7 +188,10 @@ final class SplitFlapConfigureSheetController: NSObject, NSWindowDelegate {
 
     @objc private func save(_ sender: Any?) {
         configuration.displayMode = SplitFlapDisplayMode.allCases[safe: modePopup.indexOfSelectedItem] ?? .messages
+        configuration.messageSource = SplitFlapMessageSource.allCases[safe: messageSourcePopup.indexOfSelectedItem] ?? .manual
         configuration.messageText = messageTextView.string
+        configuration.customMessageURL = customURLField.stringValue
+        configuration.contentRefreshSeconds = refreshSlider.doubleValue.rounded() * 60
         configuration.messageOrder = SplitFlapMessageOrder.allCases[safe: orderPopup.indexOfSelectedItem] ?? .sequential
         configuration.messageHoldSeconds = holdSlider.doubleValue.rounded()
         configuration.waveIntervalSeconds = waveSlider.doubleValue.rounded()

--- a/SplitFlap/SplitFlapConfigureSheetController.swift
+++ b/SplitFlap/SplitFlapConfigureSheetController.swift
@@ -14,6 +14,7 @@ final class SplitFlapConfigureSheetController: NSObject, NSWindowDelegate {
     private let holdValueLabel = NSTextField(labelWithString: "")
     private let waveSlider = NSSlider(value: 8, minValue: 2, maxValue: 60, target: nil, action: nil)
     private let waveValueLabel = NSTextField(labelWithString: "")
+    private let randomAlphabetPopup = NSPopUpButton()
     private let idleShuffleButton = NSButton(checkboxWithTitle: "Shuffle idle panels between waves", target: nil, action: nil)
     private let idleDensitySlider = NSSlider(value: 0.04, minValue: 0, maxValue: 0.2, target: nil, action: nil)
     private let idleDensityValueLabel = NSTextField(labelWithString: "")
@@ -25,7 +26,7 @@ final class SplitFlapConfigureSheetController: NSObject, NSWindowDelegate {
         self.configuration = configuration
         self.onSave = onSave
         self.window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 560, height: 560),
+            contentRect: NSRect(x: 0, y: 0, width: 560, height: 600),
             styleMask: [.titled],
             backing: .buffered,
             defer: false
@@ -53,6 +54,7 @@ final class SplitFlapConfigureSheetController: NSObject, NSWindowDelegate {
 
         modePopup.addItems(withTitles: SplitFlapDisplayMode.allCases.map(\.title))
         orderPopup.addItems(withTitles: SplitFlapMessageOrder.allCases.map(\.title))
+        randomAlphabetPopup.addItems(withTitles: SplitFlapRandomAlphabet.allCases.map(\.title))
         themePopup.addItems(withTitles: SplitFlapTheme.allCases.map(\.title))
 
         messageTextView.minSize = NSSize(width: 0, height: 120)
@@ -85,6 +87,7 @@ final class SplitFlapConfigureSheetController: NSObject, NSWindowDelegate {
         stack.addArrangedSubview(row(label: "Message order", control: orderPopup))
         stack.addArrangedSubview(sliderRow(label: "Message hold", slider: holdSlider, valueLabel: holdValueLabel))
         stack.addArrangedSubview(sliderRow(label: "Idle interval", slider: waveSlider, valueLabel: waveValueLabel))
+        stack.addArrangedSubview(row(label: "Random alphabet", control: randomAlphabetPopup))
         stack.addArrangedSubview(idleShuffleButton)
         stack.addArrangedSubview(sliderRow(label: "Idle density", slider: idleDensitySlider, valueLabel: idleDensityValueLabel))
         stack.addArrangedSubview(sliderRow(label: "Board rows", slider: rowsSlider, valueLabel: rowsValueLabel))
@@ -121,6 +124,7 @@ final class SplitFlapConfigureSheetController: NSObject, NSWindowDelegate {
         orderPopup.selectItem(at: SplitFlapMessageOrder.allCases.firstIndex(of: configuration.messageOrder) ?? 0)
         holdSlider.doubleValue = configuration.messageHoldSeconds
         waveSlider.doubleValue = configuration.waveIntervalSeconds
+        randomAlphabetPopup.selectItem(at: SplitFlapRandomAlphabet.allCases.firstIndex(of: configuration.randomAlphabet) ?? 0)
         idleShuffleButton.state = configuration.idleShuffleEnabled ? .on : .off
         idleDensitySlider.doubleValue = configuration.idleDensity
         rowsSlider.integerValue = configuration.targetRows
@@ -173,6 +177,7 @@ final class SplitFlapConfigureSheetController: NSObject, NSWindowDelegate {
         configuration.messageOrder = SplitFlapMessageOrder.allCases[safe: orderPopup.indexOfSelectedItem] ?? .sequential
         configuration.messageHoldSeconds = holdSlider.doubleValue.rounded()
         configuration.waveIntervalSeconds = waveSlider.doubleValue.rounded()
+        configuration.randomAlphabet = SplitFlapRandomAlphabet.allCases[safe: randomAlphabetPopup.indexOfSelectedItem] ?? .classic
         configuration.idleShuffleEnabled = idleShuffleButton.state == .on
         configuration.idleDensity = idleDensitySlider.doubleValue
         configuration.targetRows = rowsSlider.integerValue

--- a/SplitFlap/SplitFlapConfigureSheetController.swift
+++ b/SplitFlap/SplitFlapConfigureSheetController.swift
@@ -10,6 +10,8 @@ final class SplitFlapConfigureSheetController: NSObject, NSWindowDelegate {
     private let modePopup = NSPopUpButton()
     private let messageTextView = NSTextView()
     private let orderPopup = NSPopUpButton()
+    private let holdSlider = NSSlider(value: 4, minValue: 0, maxValue: 30, target: nil, action: nil)
+    private let holdValueLabel = NSTextField(labelWithString: "")
     private let waveSlider = NSSlider(value: 8, minValue: 2, maxValue: 60, target: nil, action: nil)
     private let waveValueLabel = NSTextField(labelWithString: "")
     private let idleShuffleButton = NSButton(checkboxWithTitle: "Shuffle idle panels between waves", target: nil, action: nil)
@@ -23,7 +25,7 @@ final class SplitFlapConfigureSheetController: NSObject, NSWindowDelegate {
         self.configuration = configuration
         self.onSave = onSave
         self.window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 560, height: 520),
+            contentRect: NSRect(x: 0, y: 0, width: 560, height: 560),
             styleMask: [.titled],
             backing: .buffered,
             defer: false
@@ -71,7 +73,7 @@ final class SplitFlapConfigureSheetController: NSObject, NSWindowDelegate {
         scrollView.heightAnchor.constraint(equalToConstant: 130).isActive = true
         scrollView.widthAnchor.constraint(equalToConstant: 500).isActive = true
 
-        [waveSlider, idleDensitySlider, rowsSlider].forEach {
+        [holdSlider, waveSlider, idleDensitySlider, rowsSlider].forEach {
             $0.translatesAutoresizingMaskIntoConstraints = false
             $0.target = self
             $0.action = #selector(sliderChanged(_:))
@@ -81,7 +83,8 @@ final class SplitFlapConfigureSheetController: NSObject, NSWindowDelegate {
         stack.addArrangedSubview(row(label: "Display", control: modePopup))
         stack.addArrangedSubview(labeledBlock(label: "Messages", control: scrollView))
         stack.addArrangedSubview(row(label: "Message order", control: orderPopup))
-        stack.addArrangedSubview(sliderRow(label: "Wave interval", slider: waveSlider, valueLabel: waveValueLabel))
+        stack.addArrangedSubview(sliderRow(label: "Message hold", slider: holdSlider, valueLabel: holdValueLabel))
+        stack.addArrangedSubview(sliderRow(label: "Idle interval", slider: waveSlider, valueLabel: waveValueLabel))
         stack.addArrangedSubview(idleShuffleButton)
         stack.addArrangedSubview(sliderRow(label: "Idle density", slider: idleDensitySlider, valueLabel: idleDensityValueLabel))
         stack.addArrangedSubview(sliderRow(label: "Board rows", slider: rowsSlider, valueLabel: rowsValueLabel))
@@ -116,6 +119,7 @@ final class SplitFlapConfigureSheetController: NSObject, NSWindowDelegate {
         modePopup.selectItem(at: SplitFlapDisplayMode.allCases.firstIndex(of: configuration.displayMode) ?? 0)
         messageTextView.string = configuration.messageText
         orderPopup.selectItem(at: SplitFlapMessageOrder.allCases.firstIndex(of: configuration.messageOrder) ?? 0)
+        holdSlider.doubleValue = configuration.messageHoldSeconds
         waveSlider.doubleValue = configuration.waveIntervalSeconds
         idleShuffleButton.state = configuration.idleShuffleEnabled ? .on : .off
         idleDensitySlider.doubleValue = configuration.idleDensity
@@ -157,6 +161,7 @@ final class SplitFlapConfigureSheetController: NSObject, NSWindowDelegate {
     }
 
     private func updateValueLabels() {
+        holdValueLabel.stringValue = "\(Int(holdSlider.doubleValue.rounded())) sec"
         waveValueLabel.stringValue = "\(Int(waveSlider.doubleValue.rounded())) sec"
         idleDensityValueLabel.stringValue = "\(Int((idleDensitySlider.doubleValue * 100).rounded()))%"
         rowsValueLabel.stringValue = "\(rowsSlider.integerValue)"
@@ -166,6 +171,7 @@ final class SplitFlapConfigureSheetController: NSObject, NSWindowDelegate {
         configuration.displayMode = SplitFlapDisplayMode.allCases[safe: modePopup.indexOfSelectedItem] ?? .messages
         configuration.messageText = messageTextView.string
         configuration.messageOrder = SplitFlapMessageOrder.allCases[safe: orderPopup.indexOfSelectedItem] ?? .sequential
+        configuration.messageHoldSeconds = holdSlider.doubleValue.rounded()
         configuration.waveIntervalSeconds = waveSlider.doubleValue.rounded()
         configuration.idleShuffleEnabled = idleShuffleButton.state == .on
         configuration.idleDensity = idleDensitySlider.doubleValue

--- a/SplitFlap/SplitFlapView.swift
+++ b/SplitFlap/SplitFlapView.swift
@@ -18,6 +18,8 @@ final class SplitFlapView: ScreenSaverView {
     private var isPreviewInstance = false
     private var configuration = SplitFlapConfigurationStore.load()
     private var configureSheetController: SplitFlapConfigureSheetController?
+    private let messageFeedLoader = SplitFlapMessageFeedLoader()
+    private var messageFeedRefreshTimer: Timer?
 
     // MARK: - Init
 
@@ -56,6 +58,7 @@ final class SplitFlapView: ScreenSaverView {
 
         clock = DisplayClock(grid: g, configuration: configuration, isPreview: isPreview)
         clock?.showImmediateFrame()
+        refreshMessageFeedIfNeeded()
 
         // Do NOT use animateOneFrame() timer — animation is scheduled by
         // DisplayClock and played by Core Animation.
@@ -64,6 +67,7 @@ final class SplitFlapView: ScreenSaverView {
 
     deinit {
         removeWindowObservers()
+        stopMessageFeedRefresh()
         clock?.stop()
     }
 
@@ -150,6 +154,7 @@ final class SplitFlapView: ScreenSaverView {
         )
         clock?.update(configuration: updated)
         clock?.showImmediateFrame()
+        refreshMessageFeedIfNeeded()
         updateClockForVisibility(restartIfRunning: true)
     }
 
@@ -199,6 +204,7 @@ final class SplitFlapView: ScreenSaverView {
         if restartIfRunning || !isClockRunning {
             clock?.start(screen: window?.screen ?? NSScreen.main)
             isClockRunning = true
+            refreshMessageFeedIfNeeded()
         }
     }
 
@@ -206,5 +212,42 @@ final class SplitFlapView: ScreenSaverView {
         guard isClockRunning else { return }
         clock?.stop()
         isClockRunning = false
+    }
+
+    private func refreshMessageFeedIfNeeded() {
+        guard configuration.displayMode == .messages,
+              configuration.messageSource != .manual
+        else {
+            stopMessageFeedRefresh()
+            return
+        }
+
+        messageFeedLoader.load(configuration: configuration) { [weak self] messages in
+            self?.applyFetchedMessages(messages)
+        }
+        scheduleMessageFeedRefresh()
+    }
+
+    private func scheduleMessageFeedRefresh() {
+        messageFeedRefreshTimer?.invalidate()
+        let interval = max(60, configuration.contentRefreshSeconds)
+        let timer = Timer(timeInterval: interval, repeats: true) { [weak self] _ in
+            self?.refreshMessageFeedIfNeeded()
+        }
+        RunLoop.main.add(timer, forMode: .common)
+        messageFeedRefreshTimer = timer
+    }
+
+    private func stopMessageFeedRefresh() {
+        messageFeedRefreshTimer?.invalidate()
+        messageFeedRefreshTimer = nil
+        messageFeedLoader.cancel()
+    }
+
+    private func applyFetchedMessages(_ messages: [String]) {
+        guard !messages.isEmpty else { return }
+        configuration.fetchedMessageText = messages.joined(separator: "\n")
+        clock?.update(configuration: configuration)
+        clock?.showImmediateFrame()
     }
 }

--- a/SplitFlap/SplitFlapView.swift
+++ b/SplitFlap/SplitFlapView.swift
@@ -57,7 +57,8 @@ final class SplitFlapView: ScreenSaverView {
         clock = DisplayClock(grid: g, configuration: configuration, isPreview: isPreview)
         clock?.showImmediateFrame()
 
-        // Do NOT use animateOneFrame() timer — all animation is CAAnimation-driven.
+        // Do NOT use animateOneFrame() timer — animation is scheduled by
+        // DisplayClock and played by Core Animation.
         animationTimeInterval = 60.0  // keep ScreenSaverView's empty framework timer cold
     }
 
@@ -81,9 +82,8 @@ final class SplitFlapView: ScreenSaverView {
         stopClock()
     }
 
-    // animateOneFrame is called by ScreenSaverView's built-in timer.
-    // All actual animation runs through CABasicAnimation and DisplayClock,
-    // so we have nothing to do here.
+    // animateOneFrame is called by ScreenSaverView's built-in timer. DisplayClock
+    // schedules coarse updates separately, so we have nothing to do here.
     override func animateOneFrame() {}
 
     // MARK: - Layout
@@ -185,13 +185,9 @@ final class SplitFlapView: ScreenSaverView {
     }
 
     private var shouldRunClock: Bool {
-        guard isAnimating, let window else { return false }
-        if isPreviewInstance {
-            return window.isVisible && !window.isMiniaturized
-        }
+        guard let window else { return false }
         return window.isVisible
             && !window.isMiniaturized
-            && window.occlusionState.contains(.visible)
     }
 
     private func updateClockForVisibility(restartIfRunning: Bool = false) {


### PR DESCRIPTION
## Summary

- Keep the split-flap board all-consuming while constraining message text to a one-flap inset.
- Page long generated messages across waves so the first page does not stay pinned indefinitely.
- Start the message cursor after the initial startup frame and drive runtime updates with a coarse run-loop timer that works inside the macOS `legacyScreenSaver` host.
- Relax the visible-window gate so a loaded saver view does not freeze on its first rendered frame because AppKit occlusion state is unavailable or stale.

## Governing Issue

No governing issue is linked; this is a direct follow-up to local visual QA feedback on the installed screen saver.

## Validation

- [x] `xcodebuild -project SplitFlap.xcodeproj -scheme SplitFlap -configuration Release -derivedDataPath /private/tmp/flapline-runtime-fix-build ONLY_ACTIVE_ARCH=NO build` passed.
- [x] Static fast-check guardrails from `scripts/ci/run-fast-checks.sh` passed.
- [x] `git diff --check` passed.
- [x] Installed the built Release saver to `~/Library/Screen Savers/Flapline.saver`, signed the inner executable and outer bundle with the local Apple Development identity, and verified with `codesign --verify --deep --strict`.
- [x] Relaunched the saver host; `legacyScreenSaver` stayed running with the freshly installed bundle.

## Bootstrap Governance

- No bootstrap control-plane, runner, or GitHub policy files changed.
- Scope is limited to message target generation, startup message advancement, and screen saver runtime scheduling.

## Merge Automation

Auto-merge is not safe to enable from this author because the author cannot approve their own PR; use fallback merge-readiness after required checks pass and review is satisfied.

## Notes

- Local `bash scripts/ci/run-fast-checks.sh` hit an Xcode `clang-stat-cache` stall when using the repo `build` derived-data path. A clean derived-data path in `/private/tmp` completed successfully, and the remaining script guardrails were run separately.
