### PR TITLE
Reduce idle CPU and add Windows screen saver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 .derivedData/
 build/
 dist/
+artifacts/
+Windows/**/bin/
+Windows/**/obj/

--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 **A split-flap screensaver with somewhere to be.**
 
 Flapline brings the soft shuffle of old airport and train-station departure
-boards to your Mac. It flips, drifts, clicks through messages, shows the time
+boards to your Mac or Windows PC. It flips, drifts, clicks through messages, shows the time
 or date, and then gets out of the way when the screen saver is not running.
 
-Built in Swift with macOS `ScreenSaver`, Core Animation, and a small affection
-for mechanical things that do one job beautifully.
+Built with Swift and Core Animation on macOS, C# and WPF on Windows, and a
+small affection for mechanical things that do one job beautifully.
 
 [![Swift](https://img.shields.io/badge/Swift-5-orange?logo=swift)](https://www.swift.org/)
-![Platform](https://img.shields.io/badge/macOS-screensaver-blue)
+![Platform](https://img.shields.io/badge/macOS%20%7C%20Windows-screensaver-blue)
 ![License](https://img.shields.io/badge/license-MIT-green)
 
 ## What It Does
@@ -82,6 +82,18 @@ Xcode:
 3. Build.
 4. Copy `Flapline.saver` from the build products into `~/Library/Screen Savers/`.
 
+### Windows
+
+The Windows port builds a native, self-contained `.scr` for x64 or Arm64 with
+the .NET 8 SDK:
+
+```powershell
+.\Windows\build.ps1 -Runtime win-x64
+```
+
+See [Windows/README.md](Windows/README.md) for build, install, preview, and
+configuration details.
+
 ## Website
 
 The public site is intentionally small and static:
@@ -114,6 +126,7 @@ domain, signing, website, and release checklist.
 | `SplitFlap/` | Screensaver source code |
 | `SplitFlap/Info.plist` | Bundle metadata and principal class |
 | `SplitFlap.xcodeproj` | Xcode project |
+| `Windows/` | Native Windows `.scr` host, tests, and build/install scripts |
 | `website/` | Static public website for `flapline.app` |
 | `scripts/ci/` | Fast, extended, and release validation scripts |
 | `docs/release/` | Public launch and release guidance |

--- a/SplitFlap/CharacterSet.swift
+++ b/SplitFlap/CharacterSet.swift
@@ -41,6 +41,14 @@ struct SplitFlapCharacter: Hashable {
         return Self.drumCharacters[nextIndex]
     }
 
+    // Idle drift should advance only one mechanical position. Unknown Unicode
+    // glyphs have no drum position, so return to the blank flap in one direct
+    // transition instead of leaving that panel permanently stuck.
+    var idleSuccessor: SplitFlapCharacter {
+        let successor = next
+        return successor == self ? .space : successor
+    }
+
     // Number of forward steps needed to reach `target` from `self`.
     func stepsTo(_ target: SplitFlapCharacter) -> Int {
         guard let sourceIndex = drumIndex, let targetIndex = target.drumIndex else {

--- a/SplitFlap/DisplayClock.swift
+++ b/SplitFlap/DisplayClock.swift
@@ -50,11 +50,11 @@ final class DisplayClock: NSObject {
     }
 
     // Tick interval for the idle phase (seconds between random panel checks)
-    private let idleTickInterval: TimeInterval = 0.15
-    private let maxIdleFlipStartsPerTick: Int = 12
-    private let maxActiveIdleFlips: Int = 48
+    private let idleTickInterval: TimeInterval = 0.5
+    private let maxIdleFlipStartsPerTick: Int = 4
+    private let maxActiveIdleFlips: Int = 12
     private var runGeneration: Int = 0
-    private let tickerInterval: TimeInterval = 0.1
+    private let tickerInterval: TimeInterval = 0.5
 
     // MARK: - Init
 
@@ -214,7 +214,12 @@ final class DisplayClock: NSObject {
 
             let panel = all[index]
             guard !panel.isFlipping else { continue }
-            let target = SplitFlapCharacter.random(in: configuration.randomAlphabet)
+            // Idle drift is intentionally a single mechanical step. Choosing a
+            // random destination averaged half the 43-position drum per panel,
+            // forcing Core Animation to encode thousands of IOSurface-backed
+            // keyframes every second even though the visual intent is a small
+            // background shuffle.
+            let target = panel.currentCharacter.idleSuccessor
             guard panel.currentCharacter != target else { continue }
             animator.animateTo(
                 target,

--- a/SplitFlap/SplitFlapPanel.swift
+++ b/SplitFlap/SplitFlapPanel.swift
@@ -334,6 +334,17 @@ final class SplitFlapPanel {
         guard steps > 0 else { completion?(); return }
         guard !isFlipping else { completion?(); return }
 
+        if steps == 1 {
+            flipSingleStep(
+                to: target,
+                beginTime: beginTime,
+                batchedTransaction: batchedTransaction,
+                shouldContinue: shouldContinue,
+                completion: completion
+            )
+            return
+        }
+
         // Drum characters keep their mechanical forward sequence. Arbitrary
         // Unicode graphemes are valid targets and resolve as a direct flip.
         let seq = currentCharacter.sequence(to: target)
@@ -456,6 +467,85 @@ final class SplitFlapPanel {
             anim.isRemovedOnCompletion = false
             layer.add(anim, forKey: key)
         }
+        if !batchedTransaction {
+            CATransaction.commit()
+        }
+    }
+
+    /// The idle path overwhelmingly consists of one-position drum advances.
+    /// Installing the target top and incoming bottom contents once, then
+    /// animating only transforms, avoids four IOSurface content tracks.
+    private func flipSingleStep(
+        to target: SplitFlapCharacter,
+        beginTime: CFTimeInterval,
+        batchedTransaction: Bool,
+        shouldContinue: @escaping () -> Bool,
+        completion: (() -> Void)?
+    ) {
+        guard let targetTop = glyph(target, .top),
+              let targetBottom = glyph(target, .bottom)
+        else {
+            setCharacter(target, animated: false)
+            completion?()
+            return
+        }
+
+        beginFlipping()
+
+        if !batchedTransaction {
+            CATransaction.begin()
+            CATransaction.setDisableActions(true)
+        }
+
+        staticTopCharacter = target
+        bottomFlapCharacter = target
+        staticTopLayer.contents = targetTop
+        bottomFlapContainer.contents = targetBottom
+        bottomFlapContainer.opacity = 0
+
+        let fall = FlipAnimator.topFallDuration
+        let rise = FlipAnimator.bottomRiseDuration
+        let total = fall + rise
+
+        let topRotation = CABasicAnimation(keyPath: "transform.rotation.x")
+        topRotation.fromValue = 0.0
+        topRotation.toValue = -Double.pi / 2
+        topRotation.duration = fall
+        topRotation.timingFunction = CAMediaTimingFunction(name: .easeIn)
+
+        let bottomRotation = CABasicAnimation(keyPath: "transform.rotation.x")
+        bottomRotation.fromValue = Double.pi / 2
+        bottomRotation.toValue = 0.0
+        bottomRotation.beginTime = beginTime + fall
+        bottomRotation.duration = rise
+        bottomRotation.timingFunction = CAMediaTimingFunction(name: .easeOut)
+        bottomRotation.fillMode = .backwards
+        bottomRotation.delegate = FlipCompletionDelegate { [weak self] finished in
+            guard let self else { return }
+            guard finished, shouldContinue() else { completion?(); return }
+            self.concludeFlip(to: target)
+            completion?()
+        }
+
+        let bottomOpacity = CAKeyframeAnimation(keyPath: "opacity")
+        bottomOpacity.values = [0.0, 1.0]
+        bottomOpacity.keyTimes = [0.0, NSNumber(value: fall / total), 1.0]
+        bottomOpacity.calculationMode = .discrete
+        bottomOpacity.duration = total
+
+        for animation in [topRotation, bottomOpacity] {
+            animation.beginTime = beginTime
+            animation.fillMode = .forwards
+            animation.isRemovedOnCompletion = false
+        }
+        bottomRotation.fillMode = .both
+        bottomRotation.isRemovedOnCompletion = false
+        bottomOpacity.fillMode = .both
+
+        topFlapContainer.add(topRotation, forKey: "flipRotation")
+        bottomFlapContainer.add(bottomRotation, forKey: "flipRotation")
+        bottomFlapContainer.add(bottomOpacity, forKey: "flipOpacity")
+
         if !batchedTransaction {
             CATransaction.commit()
         }

--- a/SplitFlap/SplitFlapView.swift
+++ b/SplitFlap/SplitFlapView.swift
@@ -58,7 +58,6 @@ final class SplitFlapView: ScreenSaverView {
 
         clock = DisplayClock(grid: g, configuration: configuration, isPreview: isPreview)
         clock?.showImmediateFrame()
-        refreshMessageFeedIfNeeded()
 
         // Do NOT use animateOneFrame() timer — animation is scheduled by
         // DisplayClock and played by Core Animation.
@@ -115,6 +114,16 @@ final class SplitFlapView: ScreenSaverView {
         }
     }
 
+    override func viewDidHide() {
+        super.viewDidHide()
+        stopClock()
+    }
+
+    override func viewDidUnhide() {
+        super.viewDidUnhide()
+        updateClockForVisibility()
+    }
+
     // MARK: - Misc
 
     override var isOpaque: Bool { true }
@@ -154,7 +163,6 @@ final class SplitFlapView: ScreenSaverView {
         )
         clock?.update(configuration: updated)
         clock?.showImmediateFrame()
-        refreshMessageFeedIfNeeded()
         updateClockForVisibility(restartIfRunning: true)
     }
 
@@ -190,9 +198,11 @@ final class SplitFlapView: ScreenSaverView {
     }
 
     private var shouldRunClock: Bool {
-        guard let window else { return false }
-        return window.isVisible
-            && !window.isMiniaturized
+        guard isAnimating, let window else { return false }
+        guard !isHiddenOrHasHiddenAncestor else { return false }
+        guard window.isVisible && !window.isMiniaturized else { return false }
+        return isPreviewInstance
+            || window.occlusionState.contains(.visible)
     }
 
     private func updateClockForVisibility(restartIfRunning: Bool = false) {
@@ -212,6 +222,7 @@ final class SplitFlapView: ScreenSaverView {
         guard isClockRunning else { return }
         clock?.stop()
         isClockRunning = false
+        stopMessageFeedRefresh()
     }
 
     private func refreshMessageFeedIfNeeded() {
@@ -245,7 +256,7 @@ final class SplitFlapView: ScreenSaverView {
     }
 
     private func applyFetchedMessages(_ messages: [String]) {
-        guard !messages.isEmpty else { return }
+        guard isClockRunning, !messages.isEmpty else { return }
         configuration.fetchedMessageText = messages.joined(separator: "\n")
         clock?.update(configuration: configuration)
         clock?.showImmediateFrame()

--- a/Tests/CharacterSetPerformanceTests.swift
+++ b/Tests/CharacterSetPerformanceTests.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+@main
+private enum CharacterSetPerformanceTests {
+    static func main() {
+        for character in SplitFlapCharacter.drumCharacters {
+            let successor = character.idleSuccessor
+            precondition(
+                character.stepsTo(successor) == 1,
+                "Idle drift must encode exactly one mechanical step for \(character.displayString)"
+            )
+        }
+
+        let unicode = SplitFlapCharacter("🚆")
+        precondition(unicode.idleSuccessor == .space)
+        precondition(unicode.stepsTo(unicode.idleSuccessor) == 1)
+    }
+}

--- a/Windows/Flapline.Core/Flapline.Core.csproj
+++ b/Windows/Flapline.Core/Flapline.Core.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Flapline.Windows</RootNamespace>
+  </PropertyGroup>
+</Project>

--- a/Windows/Flapline.Core/FlaplineCore.cs
+++ b/Windows/Flapline.Core/FlaplineCore.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace Flapline.Windows;
+
+public static class FlaplineCore
+{
+    public static readonly string[] Drum = TextElements(" ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.,-/:").ToArray();
+
+    public static string IdleSuccessor(string current)
+    {
+        var normalized = TextElements(current).FirstOrDefault() ?? " ";
+        var index = Array.IndexOf(Drum, normalized);
+        return index < 0 ? " " : Drum[(index + 1) % Drum.Length];
+    }
+
+    public static string[,] TextTargets(IEnumerable<string> sourceLines, int rows, int columns)
+    {
+        var targets = EmptyTargets(rows, columns);
+        if (rows == 0 || columns == 0)
+        {
+            return targets;
+        }
+
+        var inset = rows > 2 && columns > 2 ? 1 : 0;
+        var contentRows = Math.Max(1, rows - inset * 2);
+        var contentColumns = Math.Max(1, columns - inset * 2);
+        var lines = sourceLines
+            .SelectMany(line => Wrap(TextElements(line), contentColumns))
+            .Take(contentRows)
+            .ToArray();
+        var startRow = inset + Math.Max(0, (contentRows - lines.Length) / 2);
+
+        for (var rowOffset = 0; rowOffset < lines.Length; rowOffset++)
+        {
+            var line = lines[rowOffset];
+            var startColumn = inset + Math.Max(0, (contentColumns - line.Count) / 2);
+            for (var column = 0; column < line.Count; column++)
+            {
+                targets[startRow + rowOffset, startColumn + column] = line[column];
+            }
+        }
+
+        return targets;
+    }
+
+    public static string[,] RandomTargets(int rows, int columns, Random random)
+    {
+        var targets = EmptyTargets(rows, columns);
+        for (var row = 0; row < rows; row++)
+        {
+            for (var column = 0; column < columns; column++)
+            {
+                targets[row, column] = Drum[random.Next(Drum.Length)];
+            }
+        }
+        return targets;
+    }
+
+    public static IEnumerable<string> TextElements(string value)
+    {
+        var enumerator = StringInfo.GetTextElementEnumerator(value ?? string.Empty);
+        while (enumerator.MoveNext())
+        {
+            yield return enumerator.GetTextElement().ToUpperInvariant();
+        }
+    }
+
+    private static string[,] EmptyTargets(int rows, int columns)
+    {
+        var targets = new string[Math.Max(rows, 0), Math.Max(columns, 0)];
+        for (var row = 0; row < targets.GetLength(0); row++)
+        {
+            for (var column = 0; column < targets.GetLength(1); column++)
+            {
+                targets[row, column] = " ";
+            }
+        }
+        return targets;
+    }
+
+    private static IEnumerable<IReadOnlyList<string>> Wrap(IEnumerable<string> elements, int width)
+    {
+        var line = new List<string>(width);
+        foreach (var element in elements)
+        {
+            line.Add(element);
+            if (line.Count == width)
+            {
+                yield return line;
+                line = new List<string>(width);
+            }
+        }
+
+        if (line.Count > 0)
+        {
+            yield return line;
+        }
+    }
+}

--- a/Windows/Flapline.Core/ScreenSaverCommand.cs
+++ b/Windows/Flapline.Core/ScreenSaverCommand.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+
+namespace Flapline.Windows;
+
+public enum ScreenSaverMode
+{
+    Configure,
+    FullScreen,
+    Preview
+}
+
+public readonly record struct ScreenSaverCommand(ScreenSaverMode Mode, nint PreviewHandle = 0)
+{
+    public static ScreenSaverCommand Parse(IReadOnlyList<string> arguments)
+    {
+        if (arguments.Count == 0)
+        {
+            return new(ScreenSaverMode.Configure);
+        }
+
+        var first = arguments[0].Trim();
+        var parts = first.Split(new[] { ':', '=' }, 2);
+        var option = parts[0].ToLowerInvariant();
+
+        if (option is "/s" or "-s")
+        {
+            return new(ScreenSaverMode.FullScreen);
+        }
+
+        if (option is "/p" or "-p")
+        {
+            var handleText = parts.Length == 2
+                ? parts[1]
+                : arguments.Count > 1 ? arguments[1] : string.Empty;
+            return long.TryParse(handleText, out var handle)
+                ? new(ScreenSaverMode.Preview, (nint)handle)
+                : new(ScreenSaverMode.Configure);
+        }
+
+        return new(ScreenSaverMode.Configure);
+    }
+}

--- a/Windows/Flapline.Windows.Tests/Flapline.Windows.Tests.csproj
+++ b/Windows/Flapline.Windows.Tests/Flapline.Windows.Tests.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Flapline.Core/Flapline.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/Windows/Flapline.Windows.Tests/Program.cs
+++ b/Windows/Flapline.Windows.Tests/Program.cs
@@ -1,0 +1,27 @@
+using Flapline.Windows;
+
+foreach (var character in FlaplineCore.Drum)
+{
+    var successor = FlaplineCore.IdleSuccessor(character);
+    var sourceIndex = Array.IndexOf(FlaplineCore.Drum, character);
+    var targetIndex = Array.IndexOf(FlaplineCore.Drum, successor);
+    Assert(targetIndex == (sourceIndex + 1) % FlaplineCore.Drum.Length, "Idle drift skipped a drum position.");
+}
+Assert(FlaplineCore.IdleSuccessor("🚆") == " ", "Unicode idle drift must settle to blank in one direct transition.");
+
+var targets = FlaplineCore.TextTargets(new[] { "HI" }, 5, 7);
+Assert(targets[2, 2] == "H" && targets[2, 3] == "I", "Text should be centered inside the one-cell border.");
+Assert(targets[0, 0] == " ", "Text layout must preserve the one-cell border.");
+
+Assert(ScreenSaverCommand.Parse(new[] { "/s" }).Mode == ScreenSaverMode.FullScreen, "/s parsing failed.");
+var preview = ScreenSaverCommand.Parse(new[] { "/p", "1234" });
+Assert(preview.Mode == ScreenSaverMode.Preview && preview.PreviewHandle == 1234, "/p parsing failed.");
+Assert(ScreenSaverCommand.Parse(Array.Empty<string>()).Mode == ScreenSaverMode.Configure, "Default mode must configure.");
+
+static void Assert(bool condition, string message)
+{
+    if (!condition)
+    {
+        throw new InvalidOperationException(message);
+    }
+}

--- a/Windows/Flapline.Windows/App.xaml
+++ b/Windows/Flapline.Windows/App.xaml
@@ -1,0 +1,4 @@
+<Application x:Class="Flapline.Windows.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             ShutdownMode="OnExplicitShutdown" />

--- a/Windows/Flapline.Windows/App.xaml.cs
+++ b/Windows/Flapline.Windows/App.xaml.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+using System.Windows;
+
+namespace Flapline.Windows;
+
+public partial class App : System.Windows.Application
+{
+    private readonly List<ScreenSaverWindow> windows = new();
+
+    protected override void OnStartup(StartupEventArgs e)
+    {
+        base.OnStartup(e);
+        var command = ScreenSaverCommand.Parse(e.Args);
+        var settings = SettingsStore.Load();
+
+        switch (command.Mode)
+        {
+            case ScreenSaverMode.Configure:
+                new SettingsWindow(settings).ShowDialog();
+                Shutdown();
+                break;
+
+            case ScreenSaverMode.Preview when command.PreviewHandle != 0:
+                ShowWindow(new ScreenSaverWindow(settings, command.PreviewHandle));
+                break;
+
+            case ScreenSaverMode.FullScreen:
+                foreach (var screen in System.Windows.Forms.Screen.AllScreens)
+                {
+                    ShowWindow(new ScreenSaverWindow(settings, screen.Bounds));
+                }
+                break;
+
+            default:
+                new SettingsWindow(settings).ShowDialog();
+                Shutdown();
+                break;
+        }
+    }
+
+    private void ShowWindow(ScreenSaverWindow window)
+    {
+        window.ExitRequested += ExitScreenSaver;
+        window.Closed += (_, _) =>
+        {
+            windows.Remove(window);
+            if (windows.Count == 0)
+            {
+                Shutdown();
+            }
+        };
+        windows.Add(window);
+        window.Show();
+    }
+
+    private void ExitScreenSaver()
+    {
+        foreach (var window in windows.ToArray())
+        {
+            window.Close();
+        }
+    }
+}

--- a/Windows/Flapline.Windows/Flapline.Windows.csproj
+++ b/Windows/Flapline.Windows/Flapline.Windows.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <UseWPF>true</UseWPF>
+    <UseWindowsForms>true</UseWindowsForms>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AssemblyName>Flapline</AssemblyName>
+    <RootNamespace>Flapline.Windows</RootNamespace>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+    <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
+    <PublishSingleFile>true</PublishSingleFile>
+    <SelfContained>true</SelfContained>
+    <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
+    <DebugType>embedded</DebugType>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Flapline.Core/Flapline.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/Windows/Flapline.Windows/FlaplineSettings.cs
+++ b/Windows/Flapline.Windows/FlaplineSettings.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Linq;
+
+namespace Flapline.Windows;
+
+public enum FlaplineDisplayMode
+{
+    Messages,
+    Random,
+    Clock,
+    Date
+}
+
+public enum FlaplineTheme
+{
+    Classic,
+    Terminal,
+    Monochrome
+}
+
+public sealed class FlaplineSettings
+{
+    public const double MinimumMessageHoldSeconds = 0;
+    public const double MaximumMessageHoldSeconds = 30;
+    public const double MinimumInterWaveDelaySeconds = 2;
+    public const double MaximumInterWaveDelaySeconds = 60;
+    public const int MinimumTargetRows = 4;
+    public const int MaximumTargetRows = 24;
+
+    public FlaplineDisplayMode DisplayMode { get; set; } = FlaplineDisplayMode.Messages;
+    public string MessageText { get; set; } = "Flapline\nUnicode OK\nHello World";
+    public double MessageHoldSeconds { get; set; } = 4;
+    public double InterWaveDelaySeconds { get; set; } = 8;
+    public bool IdleShuffleEnabled { get; set; } = true;
+    public int TargetRows { get; set; } = 9;
+    public FlaplineTheme Theme { get; set; } = FlaplineTheme.Classic;
+
+    public void Normalize()
+    {
+        MessageText = string.IsNullOrWhiteSpace(MessageText) ? "Flapline" : MessageText;
+        MessageHoldSeconds = Math.Clamp(MessageHoldSeconds, MinimumMessageHoldSeconds, MaximumMessageHoldSeconds);
+        InterWaveDelaySeconds = Math.Clamp(
+            InterWaveDelaySeconds,
+            MinimumInterWaveDelaySeconds,
+            MaximumInterWaveDelaySeconds
+        );
+        TargetRows = Math.Clamp(TargetRows, MinimumTargetRows, MaximumTargetRows);
+    }
+
+    public string[] Messages => MessageText
+        .Split(new[] { "\r\n", "\n", "\r" }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+        .DefaultIfEmpty("Flapline")
+        .ToArray();
+}

--- a/Windows/Flapline.Windows/NativeMethods.cs
+++ b/Windows/Flapline.Windows/NativeMethods.cs
@@ -7,8 +7,17 @@ internal static class NativeMethods
 {
     internal const int GwlStyle = -16;
     internal const long WsChild = 0x40000000L;
+    internal const long WsPopup = 0x80000000L;
+    internal const long WsCaption = 0x00C00000L;
+    internal const long WsSysMenu = 0x00080000L;
+    internal const long WsThickFrame = 0x00040000L;
+    internal const long WsMinimizeBox = 0x00020000L;
+    internal const long WsMaximizeBox = 0x00010000L;
+    internal const uint SwpNoSize = 0x0001;
+    internal const uint SwpNoMove = 0x0002;
     internal const uint SwpNoZOrder = 0x0004;
     internal const uint SwpNoActivate = 0x0010;
+    internal const uint SwpFrameChanged = 0x0020;
 
     [StructLayout(LayoutKind.Sequential)]
     internal struct Rect

--- a/Windows/Flapline.Windows/NativeMethods.cs
+++ b/Windows/Flapline.Windows/NativeMethods.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Flapline.Windows;
+
+internal static class NativeMethods
+{
+    internal const int GwlStyle = -16;
+    internal const long WsChild = 0x40000000L;
+    internal const uint SwpNoZOrder = 0x0004;
+    internal const uint SwpNoActivate = 0x0010;
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct Rect
+    {
+        internal int Left;
+        internal int Top;
+        internal int Right;
+        internal int Bottom;
+    }
+
+    [DllImport("user32.dll", SetLastError = true)]
+    internal static extern nint SetParent(nint childWindow, nint newParent);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    internal static extern bool GetClientRect(nint window, out Rect rectangle);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    internal static extern bool SetWindowPos(
+        nint window,
+        nint insertAfter,
+        int x,
+        int y,
+        int width,
+        int height,
+        uint flags
+    );
+
+    [DllImport("user32.dll", EntryPoint = "GetWindowLongPtrW", SetLastError = true)]
+    private static extern nint GetWindowLongPtr64(nint window, int index);
+
+    [DllImport("user32.dll", EntryPoint = "GetWindowLongW", SetLastError = true)]
+    private static extern int GetWindowLong32(nint window, int index);
+
+    [DllImport("user32.dll", EntryPoint = "SetWindowLongPtrW", SetLastError = true)]
+    private static extern nint SetWindowLongPtr64(nint window, int index, nint value);
+
+    [DllImport("user32.dll", EntryPoint = "SetWindowLongW", SetLastError = true)]
+    private static extern int SetWindowLong32(nint window, int index, int value);
+
+    internal static long GetWindowStyle(nint window) => nint.Size == 8
+        ? GetWindowLongPtr64(window, GwlStyle).ToInt64()
+        : GetWindowLong32(window, GwlStyle);
+
+    internal static void SetWindowStyle(nint window, long style)
+    {
+        if (nint.Size == 8)
+        {
+            _ = SetWindowLongPtr64(window, GwlStyle, (nint)style);
+        }
+        else
+        {
+            _ = SetWindowLong32(window, GwlStyle, (int)style);
+        }
+    }
+}

--- a/Windows/Flapline.Windows/ScreenSaverWindow.cs
+++ b/Windows/Flapline.Windows/ScreenSaverWindow.cs
@@ -16,6 +16,13 @@ internal sealed class ScreenSaverWindow : Window
 
     internal event Action? ExitRequested;
 
+    private const long PreviewTopLevelStyles = NativeMethods.WsPopup
+        | NativeMethods.WsCaption
+        | NativeMethods.WsSysMenu
+        | NativeMethods.WsThickFrame
+        | NativeMethods.WsMinimizeBox
+        | NativeMethods.WsMaximizeBox;
+
     internal ScreenSaverWindow(FlaplineSettings settings, nint previewParent)
         : this(settings)
     {
@@ -63,9 +70,21 @@ internal sealed class ScreenSaverWindow : Window
         var handle = new WindowInteropHelper(this).Handle;
         if (IsPreview)
         {
-            NativeMethods.SetWindowStyle(
+            var previewStyle = (NativeMethods.GetWindowStyle(handle) | NativeMethods.WsChild)
+                & ~PreviewTopLevelStyles;
+            NativeMethods.SetWindowStyle(handle, previewStyle);
+            _ = NativeMethods.SetWindowPos(
                 handle,
-                NativeMethods.GetWindowStyle(handle) | NativeMethods.WsChild
+                0,
+                0,
+                0,
+                0,
+                0,
+                NativeMethods.SwpNoMove
+                    | NativeMethods.SwpNoSize
+                    | NativeMethods.SwpNoZOrder
+                    | NativeMethods.SwpNoActivate
+                    | NativeMethods.SwpFrameChanged
             );
             _ = NativeMethods.SetParent(handle, previewParent);
             if (NativeMethods.GetClientRect(previewParent, out var rectangle))

--- a/Windows/Flapline.Windows/ScreenSaverWindow.cs
+++ b/Windows/Flapline.Windows/ScreenSaverWindow.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Drawing;
+using System.Windows;
+using System.Windows.Input;
+using System.Windows.Interop;
+
+namespace Flapline.Windows;
+
+internal sealed class ScreenSaverWindow : Window
+{
+    private readonly SplitFlapBoard board;
+    private readonly nint previewParent;
+    private readonly Rectangle? screenBounds;
+    private System.Windows.Point? initialMousePosition;
+    private bool closingForInput;
+
+    internal event Action? ExitRequested;
+
+    internal ScreenSaverWindow(FlaplineSettings settings, nint previewParent)
+        : this(settings)
+    {
+        this.previewParent = previewParent;
+        Topmost = false;
+        ShowActivated = false;
+    }
+
+    internal ScreenSaverWindow(FlaplineSettings settings, Rectangle screenBounds)
+        : this(settings)
+    {
+        this.screenBounds = screenBounds;
+    }
+
+    private ScreenSaverWindow(FlaplineSettings settings)
+    {
+        WindowStyle = WindowStyle.None;
+        ResizeMode = ResizeMode.NoResize;
+        ShowInTaskbar = false;
+        ShowActivated = true;
+        Topmost = true;
+        Background = System.Windows.Media.Brushes.Black;
+        board = new SplitFlapBoard(settings);
+        Content = board;
+
+        SourceInitialized += HandleSourceInitialized;
+        Loaded += (_, _) => board.Start();
+        Closed += (_, _) =>
+        {
+            board.Stop();
+            if (!IsPreview)
+            {
+                Mouse.OverrideCursor = null;
+            }
+        };
+        PreviewKeyDown += (_, _) => RequestExit();
+        MouseDown += (_, _) => RequestExit();
+        MouseMove += HandleMouseMove;
+    }
+
+    private bool IsPreview => previewParent != 0;
+
+    private void HandleSourceInitialized(object? sender, EventArgs e)
+    {
+        var handle = new WindowInteropHelper(this).Handle;
+        if (IsPreview)
+        {
+            NativeMethods.SetWindowStyle(
+                handle,
+                NativeMethods.GetWindowStyle(handle) | NativeMethods.WsChild
+            );
+            _ = NativeMethods.SetParent(handle, previewParent);
+            if (NativeMethods.GetClientRect(previewParent, out var rectangle))
+            {
+                _ = NativeMethods.SetWindowPos(
+                    handle,
+                    0,
+                    0,
+                    0,
+                    rectangle.Right - rectangle.Left,
+                    rectangle.Bottom - rectangle.Top,
+                    NativeMethods.SwpNoZOrder | NativeMethods.SwpNoActivate
+                );
+            }
+            return;
+        }
+
+        if (screenBounds is { } bounds)
+        {
+            _ = NativeMethods.SetWindowPos(
+                handle,
+                0,
+                bounds.X,
+                bounds.Y,
+                bounds.Width,
+                bounds.Height,
+                NativeMethods.SwpNoZOrder | NativeMethods.SwpNoActivate
+            );
+        }
+        Mouse.OverrideCursor = Cursors.None;
+    }
+
+    private void HandleMouseMove(object sender, MouseEventArgs e)
+    {
+        if (IsPreview)
+        {
+            return;
+        }
+
+        var position = e.GetPosition(this);
+        if (initialMousePosition is null)
+        {
+            initialMousePosition = position;
+            return;
+        }
+
+        if (Math.Abs(position.X - initialMousePosition.Value.X) > 8
+            || Math.Abs(position.Y - initialMousePosition.Value.Y) > 8)
+        {
+            RequestExit();
+        }
+    }
+
+    private void RequestExit()
+    {
+        if (IsPreview || closingForInput)
+        {
+            return;
+        }
+
+        closingForInput = true;
+        Mouse.OverrideCursor = null;
+        ExitRequested?.Invoke();
+    }
+}

--- a/Windows/Flapline.Windows/SettingsStore.cs
+++ b/Windows/Flapline.Windows/SettingsStore.cs
@@ -1,0 +1,56 @@
+using System;
+using System.IO;
+using System.Text.Json;
+
+namespace Flapline.Windows;
+
+internal static class SettingsStore
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true
+    };
+
+    private static string SettingsPath => Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "Flapline",
+        "settings.json"
+    );
+
+    public static FlaplineSettings Load()
+    {
+        try
+        {
+            if (File.Exists(SettingsPath))
+            {
+                var settings = JsonSerializer.Deserialize<FlaplineSettings>(File.ReadAllText(SettingsPath), JsonOptions);
+                if (settings is not null)
+                {
+                    settings.Normalize();
+                    return settings;
+                }
+            }
+        }
+        catch (JsonException)
+        {
+            // A corrupt local preference file should not prevent the saver from starting.
+        }
+        catch (IOException)
+        {
+            // Fall back to defaults when the profile is temporarily unavailable.
+        }
+
+        return new FlaplineSettings();
+    }
+
+    public static void Save(FlaplineSettings settings)
+    {
+        settings.Normalize();
+        var directory = Path.GetDirectoryName(SettingsPath)!;
+        Directory.CreateDirectory(directory);
+
+        var temporaryPath = SettingsPath + ".tmp";
+        File.WriteAllText(temporaryPath, JsonSerializer.Serialize(settings, JsonOptions));
+        File.Move(temporaryPath, SettingsPath, overwrite: true);
+    }
+}

--- a/Windows/Flapline.Windows/SettingsWindow.cs
+++ b/Windows/Flapline.Windows/SettingsWindow.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace Flapline.Windows;
+
+internal sealed class SettingsWindow : Window
+{
+    private readonly FlaplineSettings settings;
+    private readonly ComboBox mode = new();
+    private readonly TextBox messages = new();
+    private readonly Slider hold = Slider(
+        FlaplineSettings.MinimumMessageHoldSeconds,
+        FlaplineSettings.MaximumMessageHoldSeconds
+    );
+    private readonly Slider interWaveDelay = Slider(
+        FlaplineSettings.MinimumInterWaveDelaySeconds,
+        FlaplineSettings.MaximumInterWaveDelaySeconds
+    );
+    private readonly CheckBox idle = new() { Content = "Shuffle idle panels between waves" };
+    private readonly Slider rows = Slider(
+        FlaplineSettings.MinimumTargetRows,
+        FlaplineSettings.MaximumTargetRows
+    );
+    private readonly ComboBox theme = new();
+
+    internal SettingsWindow(FlaplineSettings settings)
+    {
+        this.settings = settings;
+        Title = "Flapline Options";
+        Width = 560;
+        Height = 610;
+        ResizeMode = ResizeMode.NoResize;
+        WindowStartupLocation = WindowStartupLocation.CenterScreen;
+
+        mode.ItemsSource = Enum.GetValues<FlaplineDisplayMode>();
+        theme.ItemsSource = Enum.GetValues<FlaplineTheme>();
+        messages.AcceptsReturn = true;
+        messages.VerticalScrollBarVisibility = ScrollBarVisibility.Auto;
+        messages.Height = 150;
+        messages.TextWrapping = TextWrapping.Wrap;
+
+        mode.SelectedItem = settings.DisplayMode;
+        messages.Text = settings.MessageText;
+        hold.Value = settings.MessageHoldSeconds;
+        interWaveDelay.Value = settings.InterWaveDelaySeconds;
+        idle.IsChecked = settings.IdleShuffleEnabled;
+        rows.Value = settings.TargetRows;
+        theme.SelectedItem = settings.Theme;
+
+        var form = new StackPanel { Margin = new Thickness(24) };
+        form.Children.Add(Row("Display", mode));
+        form.Children.Add(Block("Messages", messages));
+        form.Children.Add(Row("Message hold", hold));
+        form.Children.Add(Row("Time between waves", interWaveDelay));
+        form.Children.Add(idle);
+        form.Children.Add(Row("Board rows", rows));
+        form.Children.Add(Row("Theme", theme));
+
+        var buttons = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            HorizontalAlignment = HorizontalAlignment.Right,
+            Margin = new Thickness(0, 24, 0, 0)
+        };
+        var cancel = new Button { Content = "Cancel", Width = 88, Margin = new Thickness(0, 0, 10, 0) };
+        var save = new Button { Content = "Save", Width = 88, IsDefault = true };
+        cancel.Click += (_, _) => Close();
+        save.Click += (_, _) => SaveAndClose();
+        buttons.Children.Add(cancel);
+        buttons.Children.Add(save);
+        form.Children.Add(buttons);
+        Content = form;
+    }
+
+    private void SaveAndClose()
+    {
+        settings.DisplayMode = mode.SelectedItem is FlaplineDisplayMode selectedMode
+            ? selectedMode
+            : FlaplineDisplayMode.Messages;
+        settings.MessageText = messages.Text;
+        settings.MessageHoldSeconds = Math.Round(hold.Value);
+        settings.InterWaveDelaySeconds = Math.Round(interWaveDelay.Value);
+        settings.IdleShuffleEnabled = idle.IsChecked == true;
+        settings.TargetRows = (int)Math.Round(rows.Value);
+        settings.Theme = theme.SelectedItem is FlaplineTheme selectedTheme
+            ? selectedTheme
+            : FlaplineTheme.Classic;
+        SettingsStore.Save(settings);
+        Close();
+    }
+
+    private static FrameworkElement Row(string label, FrameworkElement control)
+    {
+        control.Width = 320;
+        control.Margin = new Thickness(12, 6, 0, 6);
+        var panel = new StackPanel { Orientation = Orientation.Horizontal };
+        panel.Children.Add(new TextBlock
+        {
+            Text = label,
+            Width = 120,
+            VerticalAlignment = VerticalAlignment.Center
+        });
+        panel.Children.Add(control);
+        return panel;
+    }
+
+    private static FrameworkElement Block(string label, FrameworkElement control)
+    {
+        var panel = new StackPanel { Margin = new Thickness(0, 6, 0, 6) };
+        panel.Children.Add(new TextBlock { Text = label, Margin = new Thickness(0, 0, 0, 6) });
+        control.Width = 452;
+        panel.Children.Add(control);
+        return panel;
+    }
+
+    private static Slider Slider(double minimum, double maximum) => new()
+    {
+        Minimum = minimum,
+        Maximum = maximum,
+        TickFrequency = 1,
+        IsSnapToTickEnabled = true
+    };
+}

--- a/Windows/Flapline.Windows/SplitFlapBoard.cs
+++ b/Windows/Flapline.Windows/SplitFlapBoard.cs
@@ -1,0 +1,470 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Windows;
+using System.Windows.Media;
+using System.Windows.Threading;
+
+namespace Flapline.Windows;
+
+internal sealed class SplitFlapBoard : FrameworkElement
+{
+    private const double Gap = 2;
+    private static readonly TimeSpan FlipDuration = TimeSpan.FromMilliseconds(160);
+    private static readonly TimeSpan IdleCadence = TimeSpan.FromMilliseconds(500);
+    private static readonly TimeSpan FrameCadence = TimeSpan.FromMilliseconds(33);
+
+    private readonly FlaplineSettings settings;
+    private readonly Random random = new();
+    private readonly DispatcherTimer scheduler;
+    private readonly DispatcherTimer animationTimer;
+    private readonly Dictionary<TextCacheKey, FormattedText> textCache = new();
+    private readonly Palette palette;
+    private readonly VisualCollection visuals;
+    private CellState[,] cells = new CellState[0, 0];
+    private DrawingVisual[,] cellVisuals = new DrawingVisual[0, 0];
+    private DateTimeOffset nextContentUpdate;
+    private DateTimeOffset nextIdleUpdate;
+    private bool started;
+    private int messageIndex;
+    private int rows;
+    private int columns;
+    private double panelWidth;
+    private double panelHeight;
+    private double originX;
+    private double originY;
+    private double pixelsPerDip = 1;
+
+    internal SplitFlapBoard(FlaplineSettings settings)
+    {
+        this.settings = settings;
+        this.settings.Normalize();
+        palette = Palette.For(settings.Theme);
+        visuals = new VisualCollection(this);
+        SnapsToDevicePixels = true;
+
+        scheduler = new DispatcherTimer(DispatcherPriority.Background)
+        {
+            IsEnabled = false
+        };
+        scheduler.Tick += HandleSchedule;
+
+        animationTimer = new DispatcherTimer(DispatcherPriority.Render)
+        {
+            Interval = FrameCadence,
+            IsEnabled = false
+        };
+        animationTimer.Tick += HandleAnimationFrame;
+        SizeChanged += (_, _) => RebuildGrid();
+    }
+
+    internal void Start()
+    {
+        if (started)
+        {
+            return;
+        }
+
+        started = true;
+        RebuildGrid();
+        var now = DateTimeOffset.Now;
+        SetImmediate(CurrentTargets(advanceMessage: false));
+        nextContentUpdate = NextContentDeadline(now);
+        nextIdleUpdate = now + IdleCadence;
+        ScheduleNextWake(now);
+    }
+
+    internal void Stop()
+    {
+        started = false;
+        scheduler.Stop();
+        animationTimer.Stop();
+    }
+
+    protected override int VisualChildrenCount => visuals.Count;
+
+    protected override Visual GetVisualChild(int index) => visuals[index];
+
+    private void RebuildGrid()
+    {
+        if (ActualWidth <= 0 || ActualHeight <= 0)
+        {
+            return;
+        }
+
+        rows = settings.TargetRows;
+        panelHeight = Math.Max(12, Math.Floor((ActualHeight - Gap * (rows + 1)) / rows));
+        panelWidth = Math.Max(8, Math.Floor(panelHeight * 0.62));
+        columns = Math.Max(1, (int)Math.Floor((ActualWidth + Gap) / (panelWidth + Gap)));
+        var totalWidth = columns * (panelWidth + Gap) - Gap;
+        var totalHeight = rows * (panelHeight + Gap) - Gap;
+        originX = Math.Floor((ActualWidth - totalWidth) / 2);
+        originY = Math.Floor((ActualHeight - totalHeight) / 2);
+        pixelsPerDip = VisualTreeHelper.GetDpi(this).PixelsPerDip;
+
+        cells = new CellState[rows, columns];
+        cellVisuals = new DrawingVisual[rows, columns];
+        visuals.Clear();
+
+        var background = new DrawingVisual();
+        using (var context = background.RenderOpen())
+        {
+            context.DrawRectangle(palette.Screen, null, new Rect(RenderSize));
+        }
+        visuals.Add(background);
+
+        for (var row = 0; row < rows; row++)
+        {
+            for (var column = 0; column < columns; column++)
+            {
+                cells[row, column] = new CellState();
+                var visual = new DrawingVisual();
+                cellVisuals[row, column] = visual;
+                visuals.Add(visual);
+            }
+        }
+        textCache.Clear();
+
+        if (started)
+        {
+            SetImmediate(CurrentTargets(advanceMessage: false));
+        }
+        else
+        {
+            RenderAllCells(DateTimeOffset.Now);
+        }
+    }
+
+    private void HandleSchedule(object? sender, EventArgs e)
+    {
+        scheduler.Stop();
+        if (!started)
+        {
+            return;
+        }
+
+        var now = DateTimeOffset.Now;
+        if (now >= nextContentUpdate)
+        {
+            StartWave(CurrentTargets(advanceMessage: true), now);
+            nextContentUpdate = NextContentDeadline(now);
+        }
+
+        if (ShouldIdleShuffle && now >= nextIdleUpdate)
+        {
+            StartIdleDrift(now);
+            nextIdleUpdate = now + IdleCadence;
+        }
+
+        ScheduleNextWake(now);
+    }
+
+    private void ScheduleNextWake(DateTimeOffset now)
+    {
+        if (!started)
+        {
+            return;
+        }
+
+        var deadline = nextContentUpdate;
+        if (ShouldIdleShuffle && nextIdleUpdate < deadline)
+        {
+            deadline = nextIdleUpdate;
+        }
+
+        scheduler.Interval = TimeSpan.FromMilliseconds(Math.Max(10, (deadline - now).TotalMilliseconds));
+        scheduler.Start();
+    }
+
+    private DateTimeOffset NextContentDeadline(DateTimeOffset now)
+    {
+        return settings.DisplayMode switch
+        {
+            FlaplineDisplayMode.Clock => new DateTimeOffset(
+                now.Year,
+                now.Month,
+                now.Day,
+                now.Hour,
+                now.Minute,
+                now.Second,
+                now.Offset
+            ).AddSeconds(1),
+            FlaplineDisplayMode.Date => now.Date.AddDays(1),
+            _ => now.AddSeconds(settings.MessageHoldSeconds + settings.InterWaveDelaySeconds)
+        };
+    }
+
+    private string[,] CurrentTargets(bool advanceMessage)
+    {
+        switch (settings.DisplayMode)
+        {
+            case FlaplineDisplayMode.Random:
+                return FlaplineCore.RandomTargets(rows, columns, random);
+            case FlaplineDisplayMode.Clock:
+                return FlaplineCore.TextTargets(new[] { DateTime.Now.ToString("HH:mm:ss") }, rows, columns);
+            case FlaplineDisplayMode.Date:
+                return FlaplineCore.TextTargets(new[] { DateTime.Now.ToString("d", CultureInfo.CurrentCulture) }, rows, columns);
+            default:
+                var messages = settings.Messages;
+                if (advanceMessage)
+                {
+                    messageIndex = (messageIndex + 1) % messages.Length;
+                }
+                var selected = messages[messageIndex % messages.Length];
+                return FlaplineCore.TextTargets(new[] { selected }, rows, columns);
+        }
+    }
+
+    private void SetImmediate(string[,] targets)
+    {
+        for (var row = 0; row < rows; row++)
+        {
+            for (var column = 0; column < columns; column++)
+            {
+                cells[row, column].SetImmediate(targets[row, column]);
+            }
+        }
+        RenderAllCells(DateTimeOffset.Now);
+    }
+
+    private void StartWave(string[,] targets, DateTimeOffset now)
+    {
+        for (var column = 0; column < columns; column++)
+        {
+            var columnDelay = TimeSpan.FromMilliseconds(column * 60);
+            for (var row = 0; row < rows; row++)
+            {
+                var jitter = TimeSpan.FromMilliseconds(random.Next(0, 41));
+                cells[row, column].Begin(targets[row, column], now + columnDelay + jitter, FlipDuration);
+            }
+        }
+        StartAnimationTimerIfNeeded();
+    }
+
+    private void StartIdleDrift(DateTimeOffset now)
+    {
+        var available = rows * columns;
+        var count = Math.Clamp((int)Math.Ceiling(available * 0.01), 1, 4);
+        var selected = new HashSet<int>();
+        var attempts = 0;
+
+        while (selected.Count < count && attempts < available * 2)
+        {
+            attempts++;
+            var index = random.Next(available);
+            if (!selected.Add(index))
+            {
+                continue;
+            }
+
+            var row = index / columns;
+            var column = index % columns;
+            var cell = cells[row, column];
+            if (cell.IsTransitioning)
+            {
+                continue;
+            }
+            cell.Begin(FlaplineCore.IdleSuccessor(cell.Current), now, FlipDuration);
+        }
+        StartAnimationTimerIfNeeded();
+    }
+
+    private void StartAnimationTimerIfNeeded()
+    {
+        if (!animationTimer.IsEnabled && HasTransitions())
+        {
+            animationTimer.Start();
+        }
+    }
+
+    private void HandleAnimationFrame(object? sender, EventArgs e)
+    {
+        var now = DateTimeOffset.Now;
+        var active = false;
+        for (var row = 0; row < rows; row++)
+        {
+            for (var column = 0; column < columns; column++)
+            {
+                var cell = cells[row, column];
+                if (!cell.IsTransitioning)
+                {
+                    continue;
+                }
+
+                cell.CompleteIfNeeded(now);
+                RenderCell(row, column, now);
+                active |= cell.IsTransitioning;
+            }
+        }
+        if (!active)
+        {
+            animationTimer.Stop();
+        }
+    }
+
+    private bool HasTransitions()
+    {
+        foreach (var cell in cells)
+        {
+            if (cell.IsTransitioning)
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private bool ShouldIdleShuffle => settings.IdleShuffleEnabled
+        && settings.DisplayMode != FlaplineDisplayMode.Clock;
+
+    private void RenderAllCells(DateTimeOffset now)
+    {
+        for (var row = 0; row < rows; row++)
+        {
+            for (var column = 0; column < columns; column++)
+            {
+                RenderCell(row, column, now);
+            }
+        }
+    }
+
+    private void RenderCell(int row, int column, DateTimeOffset now)
+    {
+        var rect = new Rect(
+            originX + column * (panelWidth + Gap),
+            originY + row * (panelHeight + Gap),
+            panelWidth,
+            panelHeight
+        );
+        using var context = cellVisuals[row, column].RenderOpen();
+        DrawPanel(context, rect, cells[row, column], now);
+    }
+
+    private void DrawPanel(DrawingContext context, Rect rect, CellState cell, DateTimeOffset now)
+    {
+        context.DrawRoundedRectangle(palette.Panel, null, rect, 1.5, 1.5);
+        var progress = cell.Progress(now);
+        if (!cell.IsTransitioning || progress <= 0)
+        {
+            DrawCharacter(context, cell.Current, rect);
+        }
+        else
+        {
+            DrawCharacter(context, cell.Target, rect);
+            var half = new Rect(rect.X, rect.Y, rect.Width, rect.Height / 2);
+            var scale = progress < 0.5 ? 1 - progress * 2 : 1 - (progress - 0.5) * 2;
+            if (progress >= 0.5)
+            {
+                half.Y += rect.Height / 2;
+            }
+
+            context.PushClip(new RectangleGeometry(half));
+            context.PushTransform(new ScaleTransform(1, Math.Max(0.02, scale), rect.X + rect.Width / 2, rect.Y + rect.Height / 2));
+            DrawCharacter(context, cell.Current, rect);
+            context.Pop();
+            context.Pop();
+        }
+
+        var seamY = rect.Y + rect.Height / 2;
+        context.DrawLine(palette.Divider, new Point(rect.X, seamY), new Point(rect.Right, seamY));
+    }
+
+    private void DrawCharacter(DrawingContext context, string character, Rect rect)
+    {
+        var fontSize = Math.Max(8, rect.Height * 0.62);
+        var key = new TextCacheKey(character, (int)Math.Round(fontSize * 10), (int)Math.Round(pixelsPerDip * 100));
+        if (!textCache.TryGetValue(key, out var text))
+        {
+            text = new FormattedText(
+                character,
+                CultureInfo.CurrentCulture,
+                FlowDirection.LeftToRight,
+                new Typeface("Consolas"),
+                fontSize,
+                palette.Character,
+                pixelsPerDip
+            );
+            textCache[key] = text;
+        }
+
+        context.DrawText(
+            text,
+            new Point(
+                rect.X + (rect.Width - text.WidthIncludingTrailingWhitespace) / 2,
+                rect.Y + (rect.Height - text.Height) / 2
+            )
+        );
+    }
+
+    private readonly record struct TextCacheKey(string Text, int FontSize, int Dpi);
+
+    private sealed class CellState
+    {
+        internal string Current { get; private set; } = " ";
+        internal string Target { get; private set; } = " ";
+        internal DateTimeOffset Start { get; private set; }
+        internal TimeSpan Duration { get; private set; } = FlipDuration;
+        internal bool IsTransitioning => Current != Target;
+
+        internal void SetImmediate(string value)
+        {
+            Current = value;
+            Target = value;
+        }
+
+        internal void Begin(string target, DateTimeOffset start, TimeSpan duration)
+        {
+            if (target == Current)
+            {
+                Target = Current;
+                return;
+            }
+            Target = target;
+            Start = start;
+            Duration = duration;
+        }
+
+        internal double Progress(DateTimeOffset now)
+        {
+            if (!IsTransitioning || now <= Start)
+            {
+                return 0;
+            }
+            return Math.Clamp((now - Start).TotalMilliseconds / Duration.TotalMilliseconds, 0, 1);
+        }
+
+        internal void CompleteIfNeeded(DateTimeOffset now)
+        {
+            if (IsTransitioning && now >= Start + Duration)
+            {
+                Current = Target;
+            }
+        }
+    }
+
+    private sealed record Palette(Brush Screen, Brush Panel, Brush Character, Pen Divider)
+    {
+        internal static Palette For(FlaplineTheme theme)
+        {
+            var colors = theme switch
+            {
+                FlaplineTheme.Terminal => (Screen: "#030706", Panel: "#050D0A", Character: "#59FF94", Divider: "#000504"),
+                FlaplineTheme.Monochrome => (Screen: "#090909", Panel: "#141416", Character: "#F0F0E6", Divider: "#040405"),
+                _ => (Screen: "#0D0B08", Panel: "#191713", Character: "#F6B73C", Divider: "#050403")
+            };
+            var screen = FrozenBrush(colors.Screen);
+            var panel = FrozenBrush(colors.Panel);
+            var character = FrozenBrush(colors.Character);
+            var divider = new Pen(FrozenBrush(colors.Divider), 1);
+            divider.Freeze();
+            return new Palette(screen, panel, character, divider);
+        }
+
+        private static SolidColorBrush FrozenBrush(string color)
+        {
+            var brush = new SolidColorBrush((Color)ColorConverter.ConvertFromString(color));
+            brush.Freeze();
+            return brush;
+        }
+    }
+}

--- a/Windows/Flapline.Windows/app.manifest
+++ b/Windows/Flapline.Windows/app.manifest
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="Flapline.Windows" />
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/Windows/README.md
+++ b/Windows/README.md
@@ -1,0 +1,46 @@
+# Flapline for Windows
+
+The Windows port is a native WPF screen saver with the standard Windows entry
+points:
+
+- `/s` opens the full-screen saver on every monitor.
+- `/c` opens Flapline Options.
+- `/p <HWND>` embeds a live preview in the Windows Screen Saver Settings pane.
+
+It supports manual messages, random boards, clock and date modes, idle shuffle,
+row density, and the classic, terminal, and monochrome themes. Settings stay in
+`%LOCALAPPDATA%\Flapline\settings.json`.
+
+## Build
+
+Install the .NET 8 SDK on Windows, then run:
+
+```powershell
+.\Windows\build.ps1 -Runtime win-x64
+```
+
+Use `win-arm64` for Windows on Arm. The build runs the dependency-free core
+tests and publishes a self-contained single-file screen saver to:
+
+```text
+artifacts\win-x64\Flapline.scr
+```
+
+## Install
+
+From an elevated PowerShell window:
+
+```powershell
+.\Windows\install.ps1 -Runtime win-x64
+```
+
+The installer copies the `.scr` into `%WINDIR%\System32` and opens the Windows
+Screen Saver Settings pane. Double-clicking the build artifact opens the same
+options window without installing it.
+
+## CPU behavior
+
+The content scheduler sleeps until the next clock, message, date, or idle
+deadline. A separate 30 fps render timer starts only while one or more panels
+are transitioning and stops as soon as they settle, so a static board does not
+continuously repaint.

--- a/Windows/build.ps1
+++ b/Windows/build.ps1
@@ -1,0 +1,23 @@
+[CmdletBinding()]
+param(
+    [ValidateSet("win-x64", "win-arm64")]
+    [string]$Runtime = "win-x64"
+)
+
+$ErrorActionPreference = "Stop"
+$root = Split-Path -Parent $PSScriptRoot
+$project = Join-Path $PSScriptRoot "Flapline.Windows\Flapline.Windows.csproj"
+$tests = Join-Path $PSScriptRoot "Flapline.Windows.Tests\Flapline.Windows.Tests.csproj"
+$output = Join-Path $root "artifacts\$Runtime"
+
+dotnet run --project $tests --configuration Release
+dotnet publish $project `
+    --configuration Release `
+    --runtime $Runtime `
+    --self-contained true `
+    -p:PublishSingleFile=true `
+    -p:DebugType=None `
+    --output $output
+
+Copy-Item (Join-Path $output "Flapline.exe") (Join-Path $output "Flapline.scr") -Force
+Write-Host "Built $output\Flapline.scr"

--- a/Windows/install.ps1
+++ b/Windows/install.ps1
@@ -1,0 +1,24 @@
+[CmdletBinding()]
+param(
+    [ValidateSet("win-x64", "win-arm64")]
+    [string]$Runtime = "win-x64",
+    [string]$ScreenSaverPath
+)
+
+$ErrorActionPreference = "Stop"
+$principal = New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())
+if (-not $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    throw "Run this script from an elevated PowerShell window."
+}
+
+if (-not $ScreenSaverPath) {
+    $ScreenSaverPath = Join-Path (Split-Path -Parent $PSScriptRoot) "artifacts\$Runtime\Flapline.scr"
+}
+if (-not (Test-Path $ScreenSaverPath)) {
+    throw "Screen saver not found at $ScreenSaverPath. Run Windows\build.ps1 first."
+}
+
+$destination = Join-Path $env:WINDIR "System32\Flapline.scr"
+Copy-Item $ScreenSaverPath $destination -Force
+Write-Host "Installed Flapline to $destination"
+Start-Process control.exe -ArgumentList "desk.cpl,,1"


### PR DESCRIPTION
## Summary

- Reduce macOS idle CPU by advancing one drum position at a lower cadence and using a transform-only single-step animation path.
- Stop the clock and remote message refresh while the saver is hidden.
- Add a native Windows WPF `.scr` port with preview, configuration, multi-monitor full-screen hosting, retained per-cell rendering, tests, and build/install scripts.

## Governing Issue

No linked issue. This work was requested directly as a focused CPU review and Windows port.

## Validation

- [x] `xcrun swiftc SplitFlap/CharacterSet.swift SplitFlap/SplitFlapConfiguration.swift Tests/CharacterSetPerformanceTests.swift -framework AppKit -framework ScreenSaver -o /tmp/flapline-character-tests && /tmp/flapline-character-tests`
- [x] `xcodebuild -project SplitFlap.xcodeproj -scheme SplitFlap -configuration Release -derivedDataPath /tmp/flapline-final-derived ONLY_ACTIVE_ARCH=NO build`
- [x] `dotnet run --project Windows/Flapline.Windows.Tests/Flapline.Windows.Tests.csproj --no-restore`
- [x] `dotnet build Windows/Flapline.Windows/Flapline.Windows.csproj --no-restore --configuration Release --runtime win-x64` (0 warnings, 0 errors)
- [x] Installed and verified the universal macOS saver bundle with `codesign --verify --deep --strict`.
- [x] Sampled the live macOS preview: 7,080 of 7,087 main-thread samples were idle waiting for events; only 3 timer samples and 2 idle-tick samples remained.
- [ ] Native Windows UI/install smoke test; this environment can cross-build the port but cannot run WPF.

## Bootstrap Governance

- [x] Work is on a feature branch with project hooks enabled.
- [x] Scope is limited to performance, lifecycle handling, tests, and the Windows port.
- [x] No auth state, secrets, caches, or machine-local environment files are included.

## Merge Automation

Auto-merge is not safe to enable until required review is complete and the remaining Windows-native smoke-test risk is accepted.

## Notes

The macOS hotspot was Core Animation/IOSurface serialization caused by random long-distance idle flips. Idle motion is now intentionally lighter: at most four one-step starts every 500 ms, with no content keyframes on that path.

The Windows port supports `/s`, `/c`, and `/p <HWND>`, persists settings under LocalAppData, and publishes self-contained x64 or Arm64 screen-saver binaries. The code compiles and its portable core tests pass, but WPF runtime behavior still needs confirmation on Windows hardware.
