### PR TITLE
Add GitHub macOS notarized release

### DIFF
--- a/.github/workflows/macos-notarized-release.yml
+++ b/.github/workflows/macos-notarized-release.yml
@@ -34,45 +34,17 @@ jobs:
           [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "Version must be SemVer." >&2; exit 1; }
           echo "value=${version}" >> "$GITHUB_OUTPUT"
 
-      - name: Import Developer ID certificate
+      - name: Build, sign, notarize, and staple DMG
         shell: bash
         env:
-          CERTIFICATE_BASE64: ${{ secrets.MACOS_DEVELOPER_ID_P12_BASE64 }}
-          CERTIFICATE_PASSWORD: ${{ secrets.MACOS_DEVELOPER_ID_P12_PASSWORD }}
-          KEYCHAIN_PASSWORD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
-        run: |
-          keychain="$RUNNER_TEMP/flapline-signing.keychain-db"
-          certificate="$RUNNER_TEMP/developer-id.p12"
-          echo "$CERTIFICATE_BASE64" | base64 -D > "$certificate"
-          security create-keychain -p "$KEYCHAIN_PASSWORD" "$keychain"
-          security set-keychain-settings -lut 21600 "$keychain"
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$keychain"
-          security import "$certificate" -k "$keychain" -P "$CERTIFICATE_PASSWORD" -T /usr/bin/codesign
-          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$keychain"
-          security list-keychain -d user -s "$keychain"
-
-      - name: Build signed DMG
-        shell: bash
-        env:
-          DEVELOPER_ID_APPLICATION: ${{ secrets.MACOS_DEVELOPER_ID_APPLICATION }}
           RELEASE_VERSION: ${{ steps.version.outputs.value }}
+          APPLE_DEVELOPER_CERT_P12: ${{ secrets.APPLE_DEVELOPER_CERT_P12 }}
+          APPLE_CERT_PASSWORD: ${{ secrets.APPLE_CERT_PASSWORD }}
+          APPLE_DEVELOPER_IDENTITY: ${{ secrets.APPLE_DEVELOPER_IDENTITY }}
+          APPLE_NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
+          APPLE_NOTARY_KEY_ISSUER: ${{ secrets.APPLE_NOTARY_KEY_ISSUER }}
+          APPLE_NOTARY_PRIVATE_KEY: ${{ secrets.APPLE_NOTARY_PRIVATE_KEY }}
         run: bash scripts/ci/run-macos-notarized-release.sh
-
-      - name: Notarize and staple DMG
-        shell: bash
-        env:
-          NOTARY_KEY_BASE64: ${{ secrets.APPLE_NOTARY_KEY_BASE64 }}
-          NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
-          NOTARY_ISSUER_ID: ${{ secrets.APPLE_NOTARY_ISSUER_ID }}
-          RELEASE_VERSION: ${{ steps.version.outputs.value }}
-        run: |
-          key="$RUNNER_TEMP/AuthKey_${NOTARY_KEY_ID}.p8"
-          dmg="dist/release/Flapline-${RELEASE_VERSION}-macOS.dmg"
-          echo "$NOTARY_KEY_BASE64" | base64 -D > "$key"
-          xcrun notarytool submit "$dmg" --key "$key" --key-id "$NOTARY_KEY_ID" --issuer "$NOTARY_ISSUER_ID" --wait
-          xcrun stapler staple "$dmg"
-          xcrun stapler validate "$dmg"
-          shasum -a 256 "$dmg" > "${dmg}.sha256"
 
       - name: Publish GitHub release assets
         shell: bash

--- a/.github/workflows/macos-notarized-release.yml
+++ b/.github/workflows/macos-notarized-release.yml
@@ -25,11 +25,13 @@ jobs:
       - name: Resolve release version
         id: version
         shell: bash
+        env:
+          RELEASE_VERSION_INPUT: ${{ inputs.version }}
         run: |
           if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
             version="${GITHUB_REF_NAME#v}"
           else
-            version="${{ inputs.version }}"
+            version="${RELEASE_VERSION_INPUT}"
           fi
           [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "Version must be SemVer." >&2; exit 1; }
           echo "value=${version}" >> "$GITHUB_OUTPUT"
@@ -53,5 +55,18 @@ jobs:
           RELEASE_VERSION: ${{ steps.version.outputs.value }}
         run: |
           tag="v${RELEASE_VERSION}"
-          gh release view "$tag" >/dev/null 2>&1 || gh release create "$tag" --generate-notes
+          release_tag_sha() {
+            local tag="$1"
+            git ls-remote origin "refs/tags/$tag^{}" "refs/tags/$tag" | awk -v tag="$tag" '
+              $2 == "refs/tags/" tag "^{}" { peeled = $1 }
+              $2 == "refs/tags/" tag { direct = $1 }
+              END { print peeled != "" ? peeled : direct }
+            '
+          }
+
+          gh release view "$tag" >/dev/null 2>&1 || gh release create "$tag" --target "$GITHUB_SHA" --generate-notes
+          [[ "$(release_tag_sha "$tag")" == "$GITHUB_SHA" ]] || {
+            echo "Release tag $tag does not resolve to the built commit $GITHUB_SHA." >&2
+            exit 1
+          }
           gh release upload "$tag" dist/release/* --clobber

--- a/.github/workflows/macos-notarized-release.yml
+++ b/.github/workflows/macos-notarized-release.yml
@@ -1,0 +1,85 @@
+name: macOS Notarized Release
+
+on:
+  push:
+    tags: ['v*.*.*']
+  workflow_dispatch:
+    inputs:
+      version:
+        description: SemVer version without the v prefix
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  sign-notarize-and-publish:
+    name: Sign, notarize, and publish macOS saver
+    runs-on: macos-14
+    environment: prod
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve release version
+        id: version
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            version="${GITHUB_REF_NAME#v}"
+          else
+            version="${{ inputs.version }}"
+          fi
+          [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "Version must be SemVer." >&2; exit 1; }
+          echo "value=${version}" >> "$GITHUB_OUTPUT"
+
+      - name: Import Developer ID certificate
+        shell: bash
+        env:
+          CERTIFICATE_BASE64: ${{ secrets.MACOS_DEVELOPER_ID_P12_BASE64 }}
+          CERTIFICATE_PASSWORD: ${{ secrets.MACOS_DEVELOPER_ID_P12_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
+        run: |
+          keychain="$RUNNER_TEMP/flapline-signing.keychain-db"
+          certificate="$RUNNER_TEMP/developer-id.p12"
+          echo "$CERTIFICATE_BASE64" | base64 -D > "$certificate"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$keychain"
+          security set-keychain-settings -lut 21600 "$keychain"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$keychain"
+          security import "$certificate" -k "$keychain" -P "$CERTIFICATE_PASSWORD" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" "$keychain"
+          security list-keychain -d user -s "$keychain"
+
+      - name: Build signed DMG
+        shell: bash
+        env:
+          DEVELOPER_ID_APPLICATION: ${{ secrets.MACOS_DEVELOPER_ID_APPLICATION }}
+          RELEASE_VERSION: ${{ steps.version.outputs.value }}
+        run: bash scripts/ci/run-macos-notarized-release.sh
+
+      - name: Notarize and staple DMG
+        shell: bash
+        env:
+          NOTARY_KEY_BASE64: ${{ secrets.APPLE_NOTARY_KEY_BASE64 }}
+          NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
+          NOTARY_ISSUER_ID: ${{ secrets.APPLE_NOTARY_ISSUER_ID }}
+          RELEASE_VERSION: ${{ steps.version.outputs.value }}
+        run: |
+          key="$RUNNER_TEMP/AuthKey_${NOTARY_KEY_ID}.p8"
+          dmg="dist/release/Flapline-${RELEASE_VERSION}-macOS.dmg"
+          echo "$NOTARY_KEY_BASE64" | base64 -D > "$key"
+          xcrun notarytool submit "$dmg" --key "$key" --key-id "$NOTARY_KEY_ID" --issuer "$NOTARY_ISSUER_ID" --wait
+          xcrun stapler staple "$dmg"
+          xcrun stapler validate "$dmg"
+          shasum -a 256 "$dmg" > "${dmg}.sha256"
+
+      - name: Publish GitHub release assets
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_VERSION: ${{ steps.version.outputs.value }}
+        run: |
+          tag="v${RELEASE_VERSION}"
+          gh release view "$tag" >/dev/null 2>&1 || gh release create "$tag" --generate-notes
+          gh release upload "$tag" dist/release/* --clobber

--- a/.github/workflows/pr-fast-ci.yml
+++ b/.github/workflows/pr-fast-ci.yml
@@ -100,6 +100,21 @@ jobs:
             ONLY_ACTIVE_ARCH=NO \
             build
 
+  notarized-release-script-checks:
+    name: Notarized Release Script Checks
+    runs-on: ['self-hosted', 'linux', 'shell-only', 'public']
+    timeout-minutes: 10
+    needs: changes
+    if: >-
+      github.event.pull_request.draft == false &&
+      needs.changes.outputs.ci == 'true'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Validate macOS notarized release script
+        run: bash scripts/ci/test-macos-notarized-release.sh
   validate-pr-description:
     name: Validate PR Description
     runs-on: ['self-hosted', 'linux', 'shell-only', 'public']
@@ -170,6 +185,7 @@ jobs:
       - changes
       - fast-checks
       - macos-checks
+      - notarized-release-script-checks
       - validate-pr-description
       - validate-secrets
     steps:
@@ -179,6 +195,7 @@ jobs:
             changes=${{ needs.changes.result }}
             fast-checks=${{ needs.fast-checks.result }}
             macos-checks=${{ needs.macos-checks.result }}
+            notarized-release-script-checks=${{ needs.notarized-release-script-checks.result }}
             validate-pr-description=${{ needs.validate-pr-description.result }}
             validate-secrets=${{ needs.validate-secrets.result }}
         run: |

--- a/docs/release/public-launch.md
+++ b/docs/release/public-launch.md
@@ -73,6 +73,26 @@ For this project, plan on:
 5. Staple the ticket when the package format supports it.
 6. Attach the notarized artifact to the GitHub Release.
 
+## GitHub release signing and notarization
+
+The `macOS Notarized Release` workflow runs on an exact `vX.Y.Z` tag or by
+manual dispatch. It uses the protected `prod` GitHub environment and requires
+these environment secrets:
+
+- `MACOS_DEVELOPER_ID_P12_BASE64`: base64-encoded Developer ID Application P12.
+- `MACOS_DEVELOPER_ID_P12_PASSWORD`: password for that P12.
+- `MACOS_KEYCHAIN_PASSWORD`: an arbitrary, per-run keychain password.
+- `MACOS_DEVELOPER_ID_APPLICATION`: exact Developer ID Application certificate name.
+- `APPLE_NOTARY_KEY_BASE64`: base64-encoded App Store Connect API-key P8.
+- `APPLE_NOTARY_KEY_ID`: App Store Connect API key ID.
+- `APPLE_NOTARY_ISSUER_ID`: App Store Connect issuer ID.
+
+The workflow imports the certificate into a temporary keychain, signs the
+bundle with hardened runtime and a secure timestamp, creates a DMG, notarizes
+it with `notarytool`, staples the resulting ticket, and uploads the DMG plus a
+SHA-256 checksum to the matching GitHub Release. No Apple credential belongs in
+the repository or in unprotected repository-level secrets.
+
 ## Release Checklist
 
 Before `v1.0.0`:

--- a/docs/release/public-launch.md
+++ b/docs/release/public-launch.md
@@ -79,15 +79,14 @@ The `macOS Notarized Release` workflow runs on an exact `vX.Y.Z` tag or by
 manual dispatch. It uses the protected `prod` GitHub environment and requires
 these environment secrets:
 
-- `MACOS_DEVELOPER_ID_P12_BASE64`: base64-encoded Developer ID Application P12.
-- `MACOS_DEVELOPER_ID_P12_PASSWORD`: password for that P12.
-- `MACOS_KEYCHAIN_PASSWORD`: an arbitrary, per-run keychain password.
-- `MACOS_DEVELOPER_ID_APPLICATION`: exact Developer ID Application certificate name.
-- `APPLE_NOTARY_KEY_BASE64`: base64-encoded App Store Connect API-key P8.
+- `APPLE_DEVELOPER_CERT_P12`: base64-encoded Developer ID Application P12.
+- `APPLE_CERT_PASSWORD`: password for that P12.
+- `APPLE_DEVELOPER_IDENTITY`: exact Developer ID Application certificate name.
+- `APPLE_NOTARY_PRIVATE_KEY`: base64-encoded App Store Connect API-key P8.
 - `APPLE_NOTARY_KEY_ID`: App Store Connect API key ID.
-- `APPLE_NOTARY_ISSUER_ID`: App Store Connect issuer ID.
+- `APPLE_NOTARY_KEY_ISSUER`: App Store Connect issuer ID.
 
-The workflow imports the certificate into a temporary keychain, signs the
+These names match APW CLI's existing release contract. The workflow imports the certificate into a temporary keychain, signs the
 bundle with hardened runtime and a secure timestamp, creates a DMG, notarizes
 it with `notarytool`, staples the resulting ticket, and uploads the DMG plus a
 SHA-256 checksum to the matching GitHub Release. No Apple credential belongs in

--- a/scripts/ci/run-macos-notarized-release.sh
+++ b/scripts/ci/run-macos-notarized-release.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${DEVELOPER_ID_APPLICATION:?Set DEVELOPER_ID_APPLICATION to the Developer ID Application certificate name.}"
+: "${RELEASE_VERSION:?Set RELEASE_VERSION to the release version without a v prefix.}"
+
+product_name="Flapline"
+build_dir="build"
+saver_path="${build_dir}/Build/Products/Release/${product_name}.saver"
+artifact_dir="dist/release"
+staging_dir="dist/staging/${product_name}.saver"
+dmg_path="${artifact_dir}/${product_name}-${RELEASE_VERSION}-macOS.dmg"
+
+rm -rf "${artifact_dir}" "dist/staging"
+mkdir -p "${artifact_dir}" "dist/staging"
+
+xcodebuild \
+  -project SplitFlap.xcodeproj \
+  -scheme SplitFlap \
+  -configuration Release \
+  -derivedDataPath "${build_dir}" \
+  ONLY_ACTIVE_ARCH=NO \
+  build
+
+[[ -d "${saver_path}" ]] || { echo "Missing ${saver_path}" >&2; exit 1; }
+cp -R "${saver_path}" "${staging_dir}"
+
+codesign --force --options runtime --timestamp --sign "${DEVELOPER_ID_APPLICATION}" \
+  "${staging_dir}/Contents/MacOS/${product_name}"
+codesign --force --options runtime --timestamp --sign "${DEVELOPER_ID_APPLICATION}" "${staging_dir}"
+codesign --verify --deep --strict --verbose=2 "${staging_dir}"
+
+hdiutil create -volname "${product_name}" -srcfolder "dist/staging" -ov -format UDZO "${dmg_path}"
+echo "${dmg_path}"

--- a/scripts/ci/run-macos-notarized-release.sh
+++ b/scripts/ci/run-macos-notarized-release.sh
@@ -1,8 +1,37 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-: "${DEVELOPER_ID_APPLICATION:?Set DEVELOPER_ID_APPLICATION to the Developer ID Application certificate name.}"
 : "${RELEASE_VERSION:?Set RELEASE_VERSION to the release version without a v prefix.}"
+
+required_env=(
+  APPLE_DEVELOPER_CERT_P12
+  APPLE_CERT_PASSWORD
+  APPLE_NOTARY_KEY_ID
+  APPLE_NOTARY_KEY_ISSUER
+  APPLE_NOTARY_PRIVATE_KEY
+)
+missing=()
+for name in "${required_env[@]}"; do
+  [[ -n "${!name:-}" ]] || missing+=("${name}")
+done
+if [[ ${#missing[@]} -gt 0 ]]; then
+  echo "Apple notarization credentials are incomplete; missing: ${missing[*]}" >&2
+  exit 1
+fi
+
+if [[ "${FLAPLINE_NOTARIZE_DRY_RUN:-0}" == "1" ]]; then
+  echo "Flapline notarization inputs are present; dry run requested."
+  exit 0
+fi
+
+for tool in codesign hdiutil security shasum xcodebuild xcrun; do
+  command -v "${tool}" >/dev/null 2>&1 || { echo "Required tool not found: ${tool}" >&2; exit 1; }
+done
+
+decode_base64() {
+  local value="$1" output="$2"
+  printf '%s' "$value" | base64 --decode >"$output" 2>/dev/null || printf '%s' "$value" | base64 -D >"$output"
+}
 
 product_name="Flapline"
 build_dir="build"
@@ -10,25 +39,47 @@ saver_path="${build_dir}/Build/Products/Release/${product_name}.saver"
 artifact_dir="dist/release"
 staging_dir="dist/staging/${product_name}.saver"
 dmg_path="${artifact_dir}/${product_name}-${RELEASE_VERSION}-macOS.dmg"
+tmp_dir="$(mktemp -d)"
+keychain="${tmp_dir}/flapline-notarization.keychain-db"
+certificate_path="${tmp_dir}/developer-id.p12"
+notary_key_path="${tmp_dir}/notary-key.p8"
+keychain_password="$(uuidgen | tr -d '-')"
+signing_identity="${APPLE_DEVELOPER_IDENTITY:-Developer ID Application}"
 
-rm -rf "${artifact_dir}" "dist/staging"
-mkdir -p "${artifact_dir}" "dist/staging"
+existing_keychains=()
+while IFS= read -r keychain_path; do
+  existing_keychains+=("${keychain_path//\"/}")
+done < <(security list-keychains -d user)
+cleanup() {
+  security list-keychains -d user -s "${existing_keychains[@]}" >/dev/null 2>&1 || true
+  security delete-keychain "$keychain" >/dev/null 2>&1 || true
+  rm -rf "$tmp_dir"
+}
+trap cleanup EXIT
 
-xcodebuild \
-  -project SplitFlap.xcodeproj \
-  -scheme SplitFlap \
-  -configuration Release \
-  -derivedDataPath "${build_dir}" \
-  ONLY_ACTIVE_ARCH=NO \
-  build
+rm -rf "$artifact_dir" "dist/staging"
+mkdir -p "$artifact_dir" "dist/staging"
 
-[[ -d "${saver_path}" ]] || { echo "Missing ${saver_path}" >&2; exit 1; }
-cp -R "${saver_path}" "${staging_dir}"
+decode_base64 "$APPLE_DEVELOPER_CERT_P12" "$certificate_path"
+decode_base64 "$APPLE_NOTARY_PRIVATE_KEY" "$notary_key_path"
+chmod 0600 "$certificate_path" "$notary_key_path"
+security create-keychain -p "$keychain_password" "$keychain"
+security set-keychain-settings -lut 21600 "$keychain"
+security unlock-keychain -p "$keychain_password" "$keychain"
+security import "$certificate_path" -k "$keychain" -P "$APPLE_CERT_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
+security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$keychain_password" "$keychain"
+security list-keychains -d user -s "$keychain" "${existing_keychains[@]}"
 
-codesign --force --options runtime --timestamp --sign "${DEVELOPER_ID_APPLICATION}" \
-  "${staging_dir}/Contents/MacOS/${product_name}"
-codesign --force --options runtime --timestamp --sign "${DEVELOPER_ID_APPLICATION}" "${staging_dir}"
-codesign --verify --deep --strict --verbose=2 "${staging_dir}"
+xcodebuild -project SplitFlap.xcodeproj -scheme SplitFlap -configuration Release -derivedDataPath "$build_dir" ONLY_ACTIVE_ARCH=NO build
+[[ -d "$saver_path" ]] || { echo "Missing $saver_path" >&2; exit 1; }
+cp -R "$saver_path" "$staging_dir"
+codesign --force --options runtime --timestamp --sign "$signing_identity" "$staging_dir/Contents/MacOS/$product_name"
+codesign --force --options runtime --timestamp --sign "$signing_identity" "$staging_dir"
+codesign --verify --deep --strict --verbose=2 "$staging_dir"
 
-hdiutil create -volname "${product_name}" -srcfolder "dist/staging" -ov -format UDZO "${dmg_path}"
-echo "${dmg_path}"
+hdiutil create -volname "$product_name" -srcfolder dist/staging -ov -format UDZO "$dmg_path"
+xcrun notarytool submit "$dmg_path" --key "$notary_key_path" --key-id "$APPLE_NOTARY_KEY_ID" --issuer "$APPLE_NOTARY_KEY_ISSUER" --wait
+xcrun stapler staple "$dmg_path"
+xcrun stapler validate "$dmg_path"
+shasum -a 256 "$dmg_path" >"${dmg_path}.sha256"
+echo "$dmg_path"

--- a/scripts/ci/test-macos-notarized-release.sh
+++ b/scripts/ci/test-macos-notarized-release.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+script="$root_dir/scripts/ci/run-macos-notarized-release.sh"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+required_log="$tmp_dir/required.log"
+dry_run_log="$tmp_dir/dry-run.log"
+
+if RELEASE_VERSION=1.0.0 "$script" >"$required_log" 2>&1; then
+  echo "notarized release script accepted missing credentials." >&2
+  exit 1
+fi
+grep -q "APPLE_DEVELOPER_CERT_P12" "$required_log"
+
+env \
+  RELEASE_VERSION=1.0.0 \
+  FLAPLINE_NOTARIZE_DRY_RUN=1 \
+  APPLE_DEVELOPER_CERT_P12=dGVzdA== \
+  APPLE_CERT_PASSWORD=test \
+  APPLE_NOTARY_KEY_ID=KEYID12345 \
+  APPLE_NOTARY_KEY_ISSUER=00000000-0000-0000-0000-000000000000 \
+  APPLE_NOTARY_PRIVATE_KEY=dGVzdA== \
+  "$script" >"$dry_run_log" 2>&1
+grep -q "dry run requested" "$dry_run_log"
+echo "Flapline notarization script tests passed."

--- a/scripts/ci/test-macos-notarized-release.sh
+++ b/scripts/ci/test-macos-notarized-release.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 script="$root_dir/scripts/ci/run-macos-notarized-release.sh"
+workflow="$root_dir/.github/workflows/macos-notarized-release.yml"
 tmp_dir="$(mktemp -d)"
 trap 'rm -rf "$tmp_dir"' EXIT
 
@@ -14,6 +15,14 @@ if RELEASE_VERSION=1.0.0 "$script" >"$required_log" 2>&1; then
   exit 1
 fi
 grep -q "APPLE_DEVELOPER_CERT_P12" "$required_log"
+
+grep -Fq 'RELEASE_VERSION_INPUT: ${{ inputs.version }}' "$workflow"
+if grep -Fq 'version="${{ inputs.version }}"' "$workflow"; then
+  echo "release workflow interpolates manual inputs into shell source." >&2
+  exit 1
+fi
+grep -Fq 'gh release create "$tag" --target "$GITHUB_SHA" --generate-notes' "$workflow"
+grep -Fq 'git ls-remote origin "refs/tags/$tag^{}" "refs/tags/$tag"' "$workflow"
 
 env \
   RELEASE_VERSION=1.0.0 \


### PR DESCRIPTION
## Summary

- Add a GitHub Actions release workflow that imports a Developer ID certificate into a temporary keychain.
- Build, sign, notarize, staple, checksum, and publish a versioned Flapline DMG.
- Document the protected `prod` environment secrets required for unattended Apple release signing.

## Governing Issue

No linked issue. This release automation was explicitly requested by the project owner.

## Validation

- [x] `bash -n scripts/ci/run-macos-notarized-release.sh`
- [x] `actionlint .github/workflows/macos-notarized-release.yml`
- [x] `bash scripts/ci/run-release-verification.sh`
- [ ] Apple signing and notarization require the protected `prod` environment secrets to be configured before the workflow can run.

## Bootstrap Governance

- [x] Work is on a feature branch.
- [x] Signing material is referenced only as protected GitHub environment secrets.
- [x] No certificate, private key, Apple credential, or local environment file is committed.

## Merge Automation

Auto-merge is not safe to enable until the release-workflow review is complete and the protected Apple signing inputs are configured.

## Notes

The workflow uses an App Store Connect API key with `notarytool`, avoiding an Apple ID password in automation. It creates a stapled DMG and SHA-256 checksum for each exact SemVer tag or approved manual release.
