### PR TITLE
ci: upgrade paths-filter to v4

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,30 @@
+## Summary
+
+-
+
+## Governing Issue
+
+Refs #<issue-number>  <!-- use Closes/Fixes/Resolves only when this PR fully completes the issue; otherwise use Refs/Part of, owner/repo#123, a full GitHub issue URL, or explain why no issue is linked -->
+
+## Validation
+
+- [ ] Relevant local checks passed
+- [ ] Required PR checks are expected to satisfy `CI Gate`
+- [ ] Skipped checks are explained below
+
+## Bootstrap Governance
+
+- [ ] Changes are scoped to the linked issue
+- [ ] Contributor or PR guidance changes are reflected in `CONTRIBUTING.md`, `.github/PULL_REQUEST_TEMPLATE.md`, and `docs/bootstrap/onboarding.md` when applicable
+- [ ] PR author enabled auto-merge where GitHub allows it, or GitHub plan-limit evidence/unavailable reason is recorded and the fallback merge-readiness policy applies
+- [ ] No real secrets, runtime auth, or machine-local env files are committed
+
+
+
+## Merge Automation
+
+- [ ] PR author enabled auto-merge with `gh pr merge --auto --squash`, or the reason it is unavailable/unsafe is noted below
+
+## Notes
+
+-

--- a/.github/workflows/extended-validation.yml
+++ b/.github/workflows/extended-validation.yml
@@ -46,7 +46,7 @@ jobs:
           extended=true
           EOF
 
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         if: github.event_name == 'push'
         with:

--- a/.github/workflows/pr-fast-ci.yml
+++ b/.github/workflows/pr-fast-ci.yml
@@ -29,7 +29,7 @@ jobs:
       ci: ${{ steps.filter.outputs.ci }}
       apple: ${{ steps.filter.outputs.apple }}
     steps:
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |

--- a/project.bootstrap.yaml
+++ b/project.bootstrap.yaml
@@ -14,6 +14,7 @@ repo:
     - CODEOWNERS
     - .githooks/**
     - .devcontainer/**
+    - .github/PULL_REQUEST_TEMPLATE.md
     - .github/workflows/pr-fast-ci.yml
     - .github/workflows/extended-validation.yml
     - .github/workflows/claude.yml


### PR DESCRIPTION
## Summary

- Refresh the Bootstrap-managed PR Fast CI and Extended Validation workflows from `dorny/paths-filter@v3` to the Node 24-compatible v4 release.
- Repair the repository manifest’s PR-template managed path so Bootstrap plan mode can validate the rollout before applying it.

## Governing Issue

Refs OMT-Global/bootstrap#50.

## Validation

- [x] Bootstrap plan mode completed after the manifest repair.
- [x] `git diff --check`
- [x] No remaining `dorny/paths-filter@v3` reference in `.github/workflows`.
- [ ] Required GitHub Actions checks will provide replacement-CI evidence after this PR is opened.

## Bootstrap Governance

- [x] Changes are limited to the issue #50 rollout and its plan-validation prerequisite.
- [x] No real secrets, runtime auth, or machine-local env files are committed.

## Merge Automation

- [ ] Enable auto-merge after the required review and CI checks pass.

## Notes

- Auto-merge is enabled with squash merge; independent review and required checks remain enforced.
- This is a plan-first downstream rollout of Bootstrap issue #50.
